### PR TITLE
Server classからhttpRequest/Response部分を分離

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ SRCS     := $(SRCDIR)/main.cpp $(SRCDIR)/server/Server.cpp $(SRCDIR)/utils.cpp \
 			$(SRCDIR)/event/Multiplexer.cpp \
 			$(SRCDIR)/event/SelectMultiplexer.cpp \
 			$(SRCDIR)/event/KqueueMultiplexer.cpp \
-			$(SRCDIR)/event/PollMultiplexer.cpp
+			$(SRCDIR)/event/PollMultiplexer.cpp \
+			$(SRCDIR)/http/HttpRequest.cpp \
+			$(SRCDIR)/http/HttpResponse.cpp
 OBJS     := $(patsubst $(SRCDIR)/%.cpp, $(OBJDIR)/%.o, $(SRCS))
 DEPS     := $(OBJS:.o=.d)
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Everything in C++ 98.
 ### nginx
 - [nginx Beginner’s Guide](https://nginx.org/en/docs/beginners_guide.html)
 - [nginx.confの解説、書き方](https://qiita.com/ponponnsan/items/23e1aa6f7dd4eadde5df)
+
 ### 42 推奨資料
 - [RFC](https://triple-underscore.github.io/http1-ja.html)
 
+### CGI
+- [PythonでCGIを用いたWebアプリケーションを作る](https://qiita.com/TSKY/items/b041de0572e6586c889c)

--- a/config/valid/server.conf
+++ b/config/valid/server.conf
@@ -1,6 +1,7 @@
 server {
     listen 8080;
-
+    root ./public;
+    
     location / {
         root ./public;
         error_page 404 /404.html;

--- a/docs/Http memo
+++ b/docs/Http memo
@@ -1,0 +1,9 @@
+/project
+  ├── Http.hpp
+  ├── Http.cpp
+  ├── HttpRequest.hpp
+  ├── HttpRequest.cpp
+  ├── HttpResponse.hpp
+  ├── HttpResponse.cpp
+
+

--- a/includes/HttpRequest.hpp
+++ b/includes/HttpRequest.hpp
@@ -1,0 +1,40 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   HttpRequest.hpp                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: koseki.yusuke <koseki.yusuke@student.42    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/02 16:44:38 by koseki.yusu       #+#    #+#             */
+/*   Updated: 2025/03/02 17:31:08 by koseki.yusu      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <fstream>
+#include <map>
+
+class HttpRequest {
+public:
+    // メンバ変数（仮）
+    std::string method;
+    std::string path;
+    std::string version;
+    std::string body;
+    std::map<std::string, std::string> headers; 
+
+    void handleHttpRequest(int clientFd, const char *buffer, int nbytes);
+    
+    // リクエストの解析
+    bool parse_http_request(const std::string &request, std::string &method, std::string &path, std::string &version);
+    
+    // GET, POST, DELETE の処理
+    void handle_get_request(int client_socket, std::string path);
+    void handle_post_request(int client_socket, const std::string &request);
+    void handle_delete_request();
+    std::string read_file(const std::string &file_path);
+};

--- a/includes/HttpResponse.hpp
+++ b/includes/HttpResponse.hpp
@@ -1,0 +1,25 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   HttpResponse.hpp                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: koseki.yusuke <koseki.yusuke@student.42    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/02 16:44:51 by koseki.yusu       #+#    #+#             */
+/*   Updated: 2025/03/02 16:51:07 by koseki.yusu      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <sys/socket.h>
+
+class HttpResponse {
+public:
+    static void send_custom_error_page(int client_socket, int status_code, const std::string &error_page);
+    static void send_error_response(int clientFd, int status_code, const std::string &message);
+    static void send_response(int client_socket, int status_code, const std::string &content, const std::string &content_type);
+};

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -11,33 +11,25 @@
 #include <unistd.h>
 #include <vector>
 
+#include "HttpRequest.hpp"
+
 class Server {
 public:
   Server(const std::map<std::string, std::vector<std::string> > &config);
   ~Server();
 
   void createSockets();
-  void handleHttpRequest(int clientFd, const char *buffer, int nbytes);
+  void handleHttp(int clientFd, const char *buffer, int nbytes);
 
 private:
   std::map<std::string, std::vector<std::string> > config;
   std::vector<int> listenPorts_;
   std::string public_root;
   std::string error_404;
+  HttpRequest httpRequest;
 
   int createListenSocket(int port);
   void listenSocket(int sockfd, std::string portStr);
-
-  void handle_get_request(int clientFd, std::string path);
-  void handle_post_request(int clientFd, const std::string &request);
-  void handle_delete_request();
-
-  bool parse_http_request(const std::string &request, std::string &method,
-                          std::string &path, std::string &version);
-  void send_error_response(int clientFd, int status_code,
-                           const std::string &message);
-  void send_custom_error_page(int clientFd, int status_code,
-                              const std::string &file_path);
 
   Server();
   Server(const Server &src);

--- a/srcs/event/PollMultiplexer.cpp
+++ b/srcs/event/PollMultiplexer.cpp
@@ -104,7 +104,7 @@ void PollMultiplexer::handleClient(std::vector<struct pollfd> &pfds,
   }
   try {
     Server *server = getServerFromClientServerMap(clientFd);
-    server->handleHttpRequest(clientFd, buffer, nbytes);
+    server->handleHttp(clientFd, buffer, nbytes);
   } catch (const std::exception &e) {
     std::cerr << "Error: " << e.what() << "\n";
     close(clientFd);

--- a/srcs/event/SelectMultiplexer.cpp
+++ b/srcs/event/SelectMultiplexer.cpp
@@ -95,7 +95,7 @@ void SelectMultiplexer::handleClient(fd_set &fdSet, int &maxFd, int clientFd) {
   }
   try {
     Server *server = getServerFromClientServerMap(clientFd);
-    server->handleHttpRequest(clientFd, buffer, nbytes);
+    server->handleHttp(clientFd, buffer, nbytes);
   } catch (const std::exception &e) {
     std::cerr << "Error: " << e.what() << "\n";
     close(clientFd);

--- a/srcs/http/HttpRequest.cpp
+++ b/srcs/http/HttpRequest.cpp
@@ -1,0 +1,85 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   HttpRequest.cpp                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: koseki.yusuke <koseki.yusuke@student.42    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/02 16:37:05 by koseki.yusu       #+#    #+#             */
+/*   Updated: 2025/03/02 16:50:34 by koseki.yusu      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "HttpRequest.hpp"
+#include "HttpResponse.hpp"
+
+void HttpRequest::handleHttpRequest(int clientFd, const char *buffer, int nbytes) {
+    (void)nbytes;
+    std::string method, path, version;
+    if (!parse_http_request(buffer, method, path, version)) {
+        HttpResponse::send_error_response(clientFd, 400, "Bad Request");
+        return;
+    }
+
+    std::cout << "HTTP Method: " << method << ", Path: " << path << "\n";
+
+    if (method == "GET") {
+        handle_get_request(clientFd, path);
+    } else if (method == "POST") {
+        handle_post_request(clientFd, buffer);
+    } else if (method == "DELETE") {
+        handle_delete_request();
+    } else {
+        HttpResponse::send_error_response(clientFd, 405, "Method Not Allowed");
+    }
+}
+
+bool HttpRequest::parse_http_request(const std::string &request, std::string &method, std::string &path, std::string &version) {
+    std::istringstream request_stream(request);
+    if (!(request_stream >> method >> path >> version)) {
+        return false;
+    }
+    return true;
+}
+
+void HttpRequest::handle_get_request(int client_socket, std::string path) {
+    if (path == "/") {
+        path = "/index.html";
+    }
+
+    std::string file_path = "./public" + path;
+    try {
+        std::cout << file_path << std::endl;
+        std::string file_content = read_file(file_path);
+        HttpResponse::send_response(client_socket, 200, file_content, "text/html");
+    } catch (const std::exception &e) {
+        HttpResponse::send_custom_error_page(client_socket, 404, "404.html");
+    }
+}
+
+void HttpRequest::handle_post_request(int client_socket, const std::string &request) {
+    size_t body_start = request.find("\r\n\r\n");
+    if (body_start == std::string::npos) {
+        HttpResponse::send_error_response(client_socket, 400, "Bad Request");
+        return;
+    }
+
+    std::string body = request.substr(body_start + 4);
+    std::cout << "Received POST body: " << body << "\n";
+
+    HttpResponse::send_response(client_socket, 200, body, "text/plain");
+}
+
+void HttpRequest::handle_delete_request() {
+    // DELETE メソッドの処理（未実装）
+}
+
+std::string HttpRequest::read_file(const std::string& file_path) {
+    std::ifstream file(file_path.c_str(), std::ios::in);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open file: " + file_path);
+    }
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+}

--- a/srcs/http/HttpResponse.cpp
+++ b/srcs/http/HttpResponse.cpp
@@ -1,0 +1,64 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   HttpResponse.cpp                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: koseki.yusuke <koseki.yusuke@student.42    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/02 16:37:08 by koseki.yusu       #+#    #+#             */
+/*   Updated: 2025/03/02 16:51:25 by koseki.yusu      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "HttpResponse.hpp"
+#include "HttpRequest.hpp"
+
+void HttpResponse::send_custom_error_page(int client_socket, int status_code, const std::string &error_page) {
+    try {
+        std::string file_content = HttpRequest().read_file("./public/" + error_page);
+
+        std::ostringstream response;
+        response << "HTTP/1.1 " << status_code << " ";
+        if (status_code == 404) {
+            response << "Not Found";
+        } else if (status_code == 405) {
+            response << "Method Not Allowed";
+        }
+        response << "\r\n";
+        response << "Content-Length: " << file_content.size() << "\r\n";
+        response << "Content-Type: text/html\r\n\r\n";
+        response << file_content;
+
+        send(client_socket, response.str().c_str(), response.str().size(), 0);
+    } catch (const std::exception &e) {
+        std::ostringstream fallback;
+        fallback << "HTTP/1.1 " << status_code << " ";
+        if (status_code == 404) {
+            fallback << "Not Found";
+        } else if (status_code == 405) {
+            fallback << "Method Not Allowed";
+        }
+        fallback << "\r\nContent-Length: 9\r\n\r\nNot Found";
+        send(client_socket, fallback.str().c_str(), fallback.str().size(), 0);
+    }
+}
+
+void HttpResponse::send_error_response(int client_socket, int status_code, const std::string &message) {
+    std::ostringstream response;
+    response << "HTTP/1.1 " << status_code << " " << message << "\r\n";
+    response << "Content-Length: " << message.size() << "\r\n";
+    response << "Content-Type: text/plain\r\n\r\n";
+    response << message;
+
+    send(client_socket, response.str().c_str(), response.str().size(), 0);
+}
+
+void HttpResponse::send_response(int client_socket, int status_code, const std::string &content, const std::string &content_type) {
+    std::ostringstream response;
+    response << "HTTP/1.1 " << status_code << " OK\r\n";
+    response << "Content-Length: " << content.size() << "\r\n";
+    response << "Content-Type: " << content_type << "\r\n\r\n";
+    response << content;
+
+    send(client_socket, response.str().c_str(), response.str().size(), 0);
+}

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils.cpp                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: koseki.yusuke <koseki.yusuke@student.42    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/18 15:47:21 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/02/25 02:43:31 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/02 16:30:41 by koseki.yusu      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,18 +20,6 @@ int print_error_message(const std::string& message)
 }
 
 
-
-// ファイルの内容を読み取るヘルパー関数
-std::string read_file(const std::string& file_path)
-{
-    std::ifstream file(file_path.c_str(), std::ios::in);
-    if (!file.is_open()) {
-        throw std::runtime_error("Failed to open file: " + file_path);
-    }
-    std::ostringstream buffer;
-    buffer << file.rdbuf();
-    return buffer.str();
-}
 
 // 拡張子に基づいてMIMEタイプを返す関数
 // std::string get_mime_type(const std::string& file_path) {


### PR DESCRIPTION
[プルリクの概要]
- http関連の処理をHttpRequest classとHttpResponse classに分けました.
- Responseもそれなりに分量出てきそうかなということで一応分けました.
- Multiplexer側でserver->handleHttpRequestを呼んでいたところは, Serverのメンバ変数にhttpRequestインスタンスを持たせて対応しました. 

[今後の分担 - HttpRequest]
A. httpRequestのparse/ヘッダーや各メソッドに渡すまでのエラーハンドリング
B. 各メソッドの処理(+CGIとの繋ぎ)とエラーハンドリング
で分けられそうかなと思います. 
プロトタイプがあるので、Bの人も並列で作業できるかと思います. 