### PR TITLE
request body の parse

### DIFF
--- a/config/valid/client_size.conf
+++ b/config/valid/client_size.conf
@@ -1,0 +1,12 @@
+server {
+    listen 8080;
+    root ./public;
+    error_page 404 /404.html;
+    client_max_body_size 200000;
+}
+
+server {
+    listen 8888;
+    root ./another_root;
+    error_page 404 /error.html;
+}

--- a/includes/HttpRequest.hpp
+++ b/includes/HttpRequest.hpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:44:38 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/24 15:48:32 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/26 03:20:39 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,8 +83,6 @@ public:
   // autoindex (directory listing)
   std::string generate_directory_listing(const std::string &dir_path);
 
-  // TODO: 未作成の関数群
-  size_t get_content_length() const { return 0; }
   void clear();
 
 private:

--- a/includes/HttpRequest.hpp
+++ b/includes/HttpRequest.hpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:44:38 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/22 16:02:54 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/24 15:48:32 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,8 +55,12 @@ public:
 
   void set_status_code(int status);
   int get_status_code() const;
+  void load_max_body_size();
+  size_t get_max_body_size() const;
 
   bool add_header(std::string &key, std::string &value);
+  bool is_in_headers(const std::string &key) const;
+  std::string get_value_from_headers(const std::string &key) const;
 
   // リクエストの解析
   // bool parse_http_request(const std::string &request, std::string &method,
@@ -87,6 +91,9 @@ private:
   HttpResponse &response;
   int status_code;
   std::string _root;
+  size_t max_body_size;
+
+  static const size_t k_default_max_body;
 
   std::string get_requested_resource(const std::string &path);
   void handle_file_request(const std::string &file_path);

--- a/includes/HttpRequestParser.hpp
+++ b/includes/HttpRequestParser.hpp
@@ -32,6 +32,7 @@ private:
   std::string buffer; // recv用の受信buffer
 
   ParseState parse_header();
+  ParseState next_parse_state() const;
   ParseState parse_body();
   ParseState parse_chunked_body();
 

--- a/includes/HttpRequestParser.hpp
+++ b/includes/HttpRequestParser.hpp
@@ -4,17 +4,14 @@
 #include <sstream>
 #include <string>
 
-#define MAX_REQUEST_LINE 10000
-#define MAX_REQUEST_TARGET 2048 // TODO: 確認
-
 class HttpRequestParser {
 public:
   HttpRequestParser(HttpRequest &http_request);
   ~HttpRequestParser();
 
   bool parse();
-  void clear(); // 状態reset
 
+  void clear();                                      // 状態reset
   void append_data(const char *data, size_t length); // データ追加
 
 private:
@@ -26,12 +23,17 @@ private:
     PARSE_DONE    // 解析の正常終了
   };
 
+  static const size_t k_max_request_line;
+  static const size_t k_max_request_target;
+
   HttpRequest &request;
   ParseState parse_state; // 解析状態
-  std::string buffer;     // recv用の受信buffer
+  size_t body_size;
+  std::string buffer; // recv用の受信buffer
 
   ParseState parse_header();
   ParseState parse_body();
+  ParseState parse_chunked_body();
 
   bool parse_request_line(std::string &line);
   bool parse_header_line(std::string &line);

--- a/includes/HttpResponse.hpp
+++ b/includes/HttpResponse.hpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:44:51 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/20 02:03:41 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/22 16:44:05 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,7 @@ public:
   void generate_custom_error_page(int status_code,
                                   const std::string &error_page);
   void generate_error_response(int status_code, const std::string &message);
+  void generate_error_response(int status_code);
   void generate_response(int status_code, const std::string &content,
                          const std::string &content_type);
   void generate_redirect(int status_code, const std::string &new_location);

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -90,3 +90,4 @@ std::string trim(const std::string &s);
 
 // convert string to number
 size_t convert_str_to_size(const std::string &num_str);
+size_t parse_hex(const std::string &s);

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -87,3 +87,6 @@ void logfd(LogLevel level, const std::string &prefix, int fd);
 std::string trim_left(const std::string &s);
 std::string trim_right(const std::string &s);
 std::string trim(const std::string &s);
+
+// convert string to number
+size_t convert_str_to_size(const std::string &num_str);

--- a/includes/types.hpp
+++ b/includes/types.hpp
@@ -18,3 +18,6 @@ typedef ConfigMap::iterator ConfigIt;
 typedef ConfigMap::const_iterator ConstConfigIt;
 typedef LocationMap::iterator LocationIt;
 typedef LocationMap::const_iterator ConstLocationIt;
+
+typedef StrToStrMap::iterator StrToStrMapIt;
+typedef StrToStrMap::const_iterator ConstStrToStrMapIt;

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -6,12 +6,12 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/18 15:47:21 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/24 21:03:22 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/24 21:20:44 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Utils.hpp"
-#include <cstdint>
+#include <limits>
 
 int print_error_message(const std::string &message) {
   std::cerr << "Error: " << message << std::endl;
@@ -146,7 +146,7 @@ size_t convert_str_to_size(const std::string &num_str) {
     return val;
   }
   if ((endptr[0] == 'M' || endptr[0] == 'm') && endptr[1] == '\0') {
-    if (val > SIZE_MAX / 1048576) {
+    if (val > std::numeric_limits<std::size_t>::max() / 1048576) {
       throw std::runtime_error("Overflow during conversion: " + num_str);
     }
     return val * 1048576;

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -6,11 +6,12 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/18 15:47:21 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/24 15:58:15 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/24 21:03:22 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Utils.hpp"
+#include <cstdint>
 
 int print_error_message(const std::string &message) {
   std::cerr << "Error: " << message << std::endl;

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/18 15:47:21 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/22 15:22:42 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/24 15:58:15 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,7 +81,7 @@ std::string read_file(const std::string &file_path) {
 //     return "application/octet-stream";
 // }
 
-LogLevel current_log_level = LOG_FUNC;
+LogLevel current_log_level = LOG_INFO;
 std::ofstream debug_log("debug.log");
 
 void log(LogLevel level, const std::string &message) {
@@ -131,4 +131,24 @@ std::string trim_right(const std::string &s) {
 std::string trim(const std::string &s) {
   std::string trimmed = trim_right(s);
   return trim_left(trimmed);
+}
+
+size_t convert_str_to_size(const std::string &num_str) {
+  char *endptr;
+  errno = 0;
+
+  unsigned long val = std::strtoul(num_str.c_str(), &endptr, 10);
+  if (errno != 0 || endptr == num_str.c_str()) {
+    throw std::runtime_error("Invalid string to convert to number: " + num_str);
+  }
+  if (*endptr == '\0') {
+    return val;
+  }
+  if ((endptr[0] == 'M' || endptr[0] == 'm') && endptr[1] == '\0') {
+    if (val > SIZE_MAX / 1048576) {
+      throw std::runtime_error("Overflow during conversion: " + num_str);
+    }
+    return val * 1048576;
+  }
+  throw std::runtime_error("Invalid suffix in number: " + num_str);
 }

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/18 15:47:21 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/24 21:20:44 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/26 02:06:36 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -134,22 +134,33 @@ std::string trim(const std::string &s) {
   return trim_left(trimmed);
 }
 
-size_t convert_str_to_size(const std::string &num_str) {
+size_t convert_str_to_size(const std::string &s) {
   char *endptr;
   errno = 0;
 
-  unsigned long val = std::strtoul(num_str.c_str(), &endptr, 10);
-  if (errno != 0 || endptr == num_str.c_str()) {
-    throw std::runtime_error("Invalid string to convert to number: " + num_str);
+  unsigned long val = std::strtoul(s.c_str(), &endptr, 10);
+  if (errno != 0 || endptr == s.c_str()) {
+    throw std::runtime_error("Invalid string to convert to number: " + s);
   }
   if (*endptr == '\0') {
     return val;
   }
   if ((endptr[0] == 'M' || endptr[0] == 'm') && endptr[1] == '\0') {
     if (val > std::numeric_limits<std::size_t>::max() / 1048576) {
-      throw std::runtime_error("Overflow during conversion: " + num_str);
+      throw std::runtime_error("Overflow during conversion: " + s);
     }
     return val * 1048576;
   }
-  throw std::runtime_error("Invalid suffix in number: " + num_str);
+  throw std::runtime_error("Invalid suffix in number: " + s);
+}
+
+size_t parse_hex(const std::string &s) {
+  char *endptr;
+  errno = 0;
+
+  unsigned long val = std::strtoul(s.c_str(), &endptr, 16);
+  if (errno != 0 || endptr == s.c_str() || *endptr != '\0') {
+    throw std::runtime_error("Invalid chunk-size: " + s);
+  }
+  return val;
 }

--- a/srcs/http/HttpRequest.cpp
+++ b/srcs/http/HttpRequest.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:37:05 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/22 16:04:48 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/22 16:46:08 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,10 @@ HttpRequest::~HttpRequest() {}
 
 void HttpRequest::handle_http_request() {
   LOG_DEBUG_FUNC();
+  if (status_code != 0) {
+    response.generate_error_response(status_code);
+    return;
+  }
 
   // std::string method, path, version;
   // if (!parse_http_request(buffer, method, path, version)) {

--- a/srcs/http/HttpRequest.cpp
+++ b/srcs/http/HttpRequest.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:37:05 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/22 16:46:08 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/24 15:51:48 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,20 +16,40 @@
 #include "Server.hpp"
 #include "Utils.hpp"
 
+const size_t HttpRequest::k_default_max_body = 104857600;
+
 // server fd 経由で, server_config, locations_configs を取得
 HttpRequest::HttpRequest(int server_fd, HttpResponse &httpResponse)
-    : response(httpResponse), status_code(0) {
+    : response(httpResponse), status_code(0),
+      max_body_size(k_default_max_body) {
   Server *server = Multiplexer::get_instance().get_server_from_map(server_fd);
   if (!server) {
     throw std::runtime_error("server not found by HttpRequest");
   }
   this->server_config = server->get_config();
   this->location_configs = server->get_locations();
+
+  // TODO: configの不正値検出は最初のconfig読み込みにうつすかも（一旦ここ）
+  try {
+    load_max_body_size();
+  } catch (const std::exception &e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+  }
 }
 
 HttpRequest::~HttpRequest() {}
 
-// HttpRequest::HttpRequest(const std::map<std::string, std::vector<std::string>
+void HttpRequest::load_max_body_size() {
+  ConstConfigIt it = server_config.find("client_max_body_size");
+  if (it != server_config.end()) {
+    std::string max_size_str = it->second.front();
+    max_body_size = convert_str_to_size(max_size_str);
+  }
+  logfd(LOG_DEBUG, "client_max_body_size loaded: ", max_body_size);
+}
+
+// HttpRequest::HttpRequest(const std::map<std::string,
+// std::vector<std::string>
 // >& config, const std::map<std::string, std::map<std::string,
 // std::vector<std::string> > >&  location_config) {
 //     this->server_configs = config;
@@ -114,7 +134,8 @@ ConfigMap HttpRequest::get_location_config(const std::string &path) {
   // 最もマッチする `location` を探す
   std::string best_match = "/";
   //   std::map<std::string,
-  //            std::map<std::string, std::vector<std::string>>>::const_iterator
+  //            std::map<std::string,
+  //            std::vector<std::string>>>::const_iterator
 
   ConstLocationIt best_match_it = location_configs.find("/");
 
@@ -195,7 +216,8 @@ void HttpRequest::handle_file_request(const std::string &file_path) {
   std::ostringstream buffer;
   buffer << file.rdbuf();
   std::string file_content = buffer.str();
-  // HttpResponse::send_response(client_socket, 200, file_content, "text/html");
+  // HttpResponse::send_response(client_socket, 200, file_content,
+  // "text/html");
   response.generate_response(200, file_content, "text/html");
 }
 
@@ -299,7 +321,8 @@ void HttpRequest::handle_post_request(const std::string &request,
     // HttpResponse::send_response(client_socket, 201, body, "text/plain");
     response.generate_response(201, body, "text/plain");
   } else {
-    // アップロードできない場合は通常のresource取得になるらしい (GETと同様処理)
+    // アップロードできない場合は通常のresource取得になるらしい
+    // (GETと同様処理)
     handle_get_request(path);
   }
 }
@@ -383,8 +406,8 @@ bool HttpRequest::is_cgi_request(const std::string &path) {
     }
   }
   return false;
-  // return (extension == ".cgi" || extension == ".php" || extension == ".py" ||
-  // extension == ".pl"); → confファイルで指示あり？
+  // return (extension == ".cgi" || extension == ".php" || extension == ".py"
+  // || extension == ".pl"); → confファイルで指示あり？
 }
 
 void HttpRequest::handle_cgi_request(const std::string &cgi_path) {
@@ -461,6 +484,20 @@ void HttpRequest::set_status_code(int status) { status_code = status; }
 
 int HttpRequest::get_status_code() const { return status_code; }
 
+size_t HttpRequest::get_max_body_size() const { return max_body_size; }
+
+bool HttpRequest::is_in_headers(const std::string &key) const {
+  return (headers.find(key) != headers.end());
+}
+
+std::string HttpRequest::get_value_from_headers(const std::string &key) const {
+  ConstStrToStrMapIt it = headers.find(key);
+  if (it != headers.end()) {
+    return it->second;
+  }
+  return "";
+}
+
 bool HttpRequest::add_header(std::string &key, std::string &value) {
   if (headers.find(key) != headers.end()) {
     return false;
@@ -484,8 +521,8 @@ HttpRequest &HttpRequest::operator=(const HttpRequest &other) {
 }
 
 // bool HttpRequest::parse_http_request(const std::string &request,
-//                                      std::string &method, std::string &path,
-//                                      std::string &version) {
+//                                      std::string &method, std::string
+//                                      &path, std::string &version) {
 //   std::istringstream request_stream(request);
 //   if (!(request_stream >> method >> path >> version)) {
 //     return false;

--- a/srcs/http/HttpRequestParser.cpp
+++ b/srcs/http/HttpRequestParser.cpp
@@ -2,6 +2,9 @@
 #include "Utils.hpp"
 #include <set>
 
+static const char *unreserved_chars = "-._~";
+static const char *reserved_chars = ":/?#[]@!$&'()*+,;=";
+
 const size_t HttpRequestParser::k_max_request_line = 10000;
 const size_t HttpRequestParser::k_max_request_target = 2048;
 
@@ -207,8 +210,15 @@ bool HttpRequestParser::validate_request_content() {
     return false;
   }
 
-  // TODO: Request url が NG文字を含む
-  // request.set_status_code(400);
+  for (size_t i = 0; i < request.path.size(); ++i) {
+    char c = request.path.at(i);
+    if (!std::isdigit(c) && !std::isalpha(c) &&
+        !std::strchr(unreserved_chars, c) && !std::strchr(reserved_chars, c)) {
+      log(LOG_DEBUG, std::string("Invalid character in target: '") + c + "'");
+      request.set_status_code(400);
+      return false;
+    }
+  }
 
   if (request.path.size() > k_max_request_target) {
     log(LOG_DEBUG, "Request-target is too long");

--- a/srcs/http/HttpResponse.cpp
+++ b/srcs/http/HttpResponse.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:37:08 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/22 16:04:38 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/22 16:45:31 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,6 @@ std::string HttpResponse::get_next_response() {
 
 void HttpResponse::pop_response() {
   LOG_DEBUG_FUNC();
-
   response_queue.pop();
 }
 
@@ -103,6 +102,18 @@ void HttpResponse::generate_error_response(int status_code,
 
   push_response(response.str());
   // send(client_socket, response.str().c_str(), response.str().size(), 0);
+}
+
+void HttpResponse::generate_error_response(int status_code) {
+  LOG_DEBUG_FUNC();
+  std::ostringstream response;
+  const std::string &message = get_status_message(status_code);
+  response << "HTTP/1.1 " << status_code << " " << message << "\r\n";
+  response << "Content-Length: " << message.size() << "\r\n";
+  response << "Content-Type: text/plain\r\n\r\n";
+  response << message;
+
+  push_response(response.str());
 }
 
 // 未実装


### PR DESCRIPTION
## request body のパース機能を実装

### 内容
- request body の読み込み
- chunked body の読み込み
- 不正な文字を含む request target（path）の検証

### 問題
バイナリの body に対応していないこと（issue: #22）
Transfer-Encoding: gzip (課題の範囲内か検討)