### PR TITLE
kequeu & epoll でのI/O多重化

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Debug file structure
         run: |
           ls -R
-          echo "CXX is set to: $CXX"
 
       - name: Clean build artifacts
         run: |

--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,24 @@ SRCDIR   := srcs
 OBJDIR   := objs
 SRCS     := $(SRCDIR)/main.cpp $(SRCDIR)/server/Server.cpp $(SRCDIR)/Utils.cpp \
             $(SRCDIR)/config/ConfigParse.cpp \
-            $(SRCDIR)/event/EpollMultiplexer.cpp \
 			$(SRCDIR)/event/Multiplexer.cpp \
 			$(SRCDIR)/event/SelectMultiplexer.cpp \
-			$(SRCDIR)/event/KqueueMultiplexer.cpp \
 			$(SRCDIR)/event/PollMultiplexer.cpp \
 			$(SRCDIR)/http/HttpRequest.cpp \
 			$(SRCDIR)/http/HttpResponse.cpp \
 			$(SRCDIR)/client/Client.cpp \
 			$(SRCDIR)/http/HttpRequestParser.cpp
+
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S),Darwin)
+  SRCS += srcs/event/KqueueMultiplexer.cpp
+endif
+
+ifeq ($(UNAME_S),Linux)
+  SRCS += srcs/event/EpollMultiplexer.cpp
+endif
+
 OBJS     := $(patsubst $(SRCDIR)/%.cpp, $(OBJDIR)/%.o, $(SRCS))
 DEPS     := $(OBJS:.o=.d)
 

--- a/README.md
+++ b/README.md
@@ -150,3 +150,6 @@ Everything in C++ 98.
 ### CGI
 - [PythonでCGIを用いたWebアプリケーションを作る](https://qiita.com/TSKY/items/b041de0572e6586c889c)
 - [CGIの仕様](https://www.tohoho-web.com/wwwcgi3.htm)
+
+### I/O multiplexing
+- [man kqueue](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kqueue.2.html)

--- a/config/valid/client_size.conf
+++ b/config/valid/client_size.conf
@@ -1,0 +1,12 @@
+server {
+    listen 8080;
+    root ./public;
+    error_page 404 /404.html;
+    client_max_body_size 200000;
+}
+
+server {
+    listen 8888;
+    root ./another_root;
+    error_page 404 /error.html;
+}

--- a/includes/HttpRequest.hpp
+++ b/includes/HttpRequest.hpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:44:38 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/24 15:48:32 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/26 03:20:39 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,8 +83,6 @@ public:
   // autoindex (directory listing)
   std::string generate_directory_listing(const std::string &dir_path);
 
-  // TODO: 未作成の関数群
-  size_t get_content_length() const { return 0; }
   void clear();
 
 private:

--- a/includes/HttpRequest.hpp
+++ b/includes/HttpRequest.hpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:44:38 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/22 16:02:54 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/24 15:48:32 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,8 +55,12 @@ public:
 
   void set_status_code(int status);
   int get_status_code() const;
+  void load_max_body_size();
+  size_t get_max_body_size() const;
 
   bool add_header(std::string &key, std::string &value);
+  bool is_in_headers(const std::string &key) const;
+  std::string get_value_from_headers(const std::string &key) const;
 
   // リクエストの解析
   // bool parse_http_request(const std::string &request, std::string &method,
@@ -87,6 +91,9 @@ private:
   HttpResponse &response;
   int status_code;
   std::string _root;
+  size_t max_body_size;
+
+  static const size_t k_default_max_body;
 
   std::string get_requested_resource(const std::string &path);
   void handle_file_request(const std::string &file_path);

--- a/includes/HttpRequestParser.hpp
+++ b/includes/HttpRequestParser.hpp
@@ -32,6 +32,7 @@ private:
   std::string buffer; // recv用の受信buffer
 
   ParseState parse_header();
+  ParseState next_parse_state() const;
   ParseState parse_body();
   ParseState parse_chunked_body();
 

--- a/includes/HttpRequestParser.hpp
+++ b/includes/HttpRequestParser.hpp
@@ -4,17 +4,14 @@
 #include <sstream>
 #include <string>
 
-#define MAX_REQUEST_LINE 10000
-#define MAX_REQUEST_TARGET 2048 // TODO: 確認
-
 class HttpRequestParser {
 public:
   HttpRequestParser(HttpRequest &http_request);
   ~HttpRequestParser();
 
   bool parse();
-  void clear(); // 状態reset
 
+  void clear();                                      // 状態reset
   void append_data(const char *data, size_t length); // データ追加
 
 private:
@@ -26,12 +23,17 @@ private:
     PARSE_DONE    // 解析の正常終了
   };
 
+  static const size_t k_max_request_line;
+  static const size_t k_max_request_target;
+
   HttpRequest &request;
   ParseState parse_state; // 解析状態
-  std::string buffer;     // recv用の受信buffer
+  size_t body_size;
+  std::string buffer; // recv用の受信buffer
 
   ParseState parse_header();
   ParseState parse_body();
+  ParseState parse_chunked_body();
 
   bool parse_request_line(std::string &line);
   bool parse_header_line(std::string &line);

--- a/includes/HttpResponse.hpp
+++ b/includes/HttpResponse.hpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:44:51 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/20 02:03:41 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/22 16:44:05 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,7 @@ public:
   void generate_custom_error_page(int status_code,
                                   const std::string &error_page);
   void generate_error_response(int status_code, const std::string &message);
+  void generate_error_response(int status_code);
   void generate_response(int status_code, const std::string &content,
                          const std::string &content_type);
   void generate_redirect(int status_code, const std::string &new_location);

--- a/includes/KqueueMultiplexer.hpp
+++ b/includes/KqueueMultiplexer.hpp
@@ -18,8 +18,15 @@ protected:
   void remove_from_write_fds(int fd);
 
 private:
-  bool is_readable(int fd);
-  bool is_writable(int fd);
+  typedef std::vector<struct kevent> KeventVec;
+  typedef std::vector<struct kevent>::iterator KeventIt;
+  typedef std::vector<struct kevent>::const_iterator ConstKeventIt;
+
+  KeventVec change_list;
+  KeventVec event_list;
+
+  bool is_readable(struct kevent &ev) const;
+  bool is_writable(struct kevent &ev) const;
 
   KqueueMultiplexer();
   KqueueMultiplexer(const KqueueMultiplexer &other);
@@ -27,3 +34,327 @@ private:
 
   KqueueMultiplexer &operator=(const KqueueMultiplexer &other);
 };
+
+// TODO: 作業用メモ. あとで消す
+/*
+
+KQUEUE(2)                   BSD System Calls Manual                  KQUEUE(2)
+
+NAME
+     kqueue, kevent -- kernel event notification mechanism
+
+LIBRARY
+     Standard C Library (libc, -lc)
+
+SYNOPSIS
+     #include <sys/types.h>
+     #include <sys/event.h>
+     #include <sys/time.h>
+
+     int
+     kqueue(void);
+
+     int
+     kevent(int kq, const struct kevent *changelist, int nchanges,
+         struct kevent *eventlist, int nevents,
+         const struct timespec *timeout);
+
+     EV_SET(&kev, ident, filter, flags, fflags, data, udata);
+
+DESCRIPTION
+     The kqueue() system call provides a generic method of notifying the user
+     when an kernel event (kevent) happens or a condition holds, based on the
+     results of small pieces of kernel code termed filters.  A kevent is
+iden-tified identified tified by an (ident, filter) pair and specifies the
+interesting condi-tions conditions tions to be notified about for that pair.  An
+(ident, filter) pair can only appear once is a given kqueue.  Subsequent
+attempts to register the same pair for a given kqueue will result in the
+replacement of the condi-tions conditions tions being watched, not an addition.
+
+     The filter identified in a kevent is executed upon the initial
+registra-tion registration tion of that event in order to detect whether a
+preexisting condition is present, and is also executed whenever an event is
+passed to the filter for evaluation.  If the filter determines that the
+condition should be reported, then the kevent is placed on the kqueue for the
+user to retrieve.
+
+     The filter is also run when the user attempts to retrieve the kevent from
+     the kqueue.  If the filter indicates that the condition that triggered
+     the event no longer holds, the kevent is removed from the kqueue and is
+     not returned.
+
+     Multiple events which trigger the filter do not result in multiple
+     kevents being placed on the kqueue; instead, the filter will aggregate
+     the events into a single struct kevent.  Calling close() on a file
+     descriptor will remove any kevents that reference the descriptor.
+
+     The kqueue() system call creates a new kernel event queue and returns a
+     descriptor.  The queue is not inherited by a child created with fork(2).
+
+     The kevent() system call is used to register events with the queue, and
+     return any pending events to the user.  The changelist argument is a
+     pointer to an array of kevent structures, as defined in <sys/event.h>.
+     All changes contained in the changelist are applied before any pending
+     events are read from the queue.  The nchanges argument gives the size of
+     changelist.  The eventlist argument is a pointer to an array of kevent
+     structures.  The nevents argument determines the size of eventlist.  If
+     timeout is a non-NULL pointer, it specifies a maximum interval to wait
+     for an event, which will be interpreted as a struct timespec.  If timeout
+     is a NULL pointer, kevent() waits indefinitely.  To effect a poll, the
+     timeout argument should be non-NULL, pointing to a zero-valued timespec
+     structure.  The same array may be used for the changelist and eventlist.
+
+     The EV_SET() macro is provided for ease of initializing a kevent
+struc-ture. structure. ture.
+ */
+// The kevent structure is defined as :
+
+//     struct kevent {
+//   uintptr_t ident; /* identifier for this event */
+//   short filter;    /* filter for event */
+//   u_short flags;   /* action flags for kqueue */
+//   u_int fflags;    /* filter flag value */
+//   intptr_t data;   /* filter data value */
+//   void *udata;     /* opaque user data identifier */
+// };
+/*
+     The fields of struct kevent are:
+
+     ident      Value used to identify this event.  The exact interpretation
+                is determined by the attached filter, but often is a file
+                descriptor.
+
+     filter     Identifies the kernel filter used to process this event.  The
+                pre-defined system filters are described below.
+
+     flags      Actions to perform on the event.
+
+     fflags     Filter-specific flags.
+
+     data       Filter-specific data value.
+
+     udata      Opaque user-defined value passed through the kernel unchanged.
+
+     The flags field can contain the following values:
+
+     EV_ADD         Adds the event to the kqueue.  Re-adding an existing event
+                    will modify the parameters of the original event, and not
+                    result in a duplicate entry.  Adding an event automati-cally
+automatically cally enables it, unless overridden by the EV_DISABLE flag.
+
+     EV_ENABLE      Permit kevent() to return the event if it is triggered.
+
+     EV_DISABLE     Disable the event so kevent() will not return it.  The
+                    filter itself is not disabled.
+
+     EV_DELETE      Removes the event from the kqueue.  Events which are
+                    attached to file descriptors are automatically deleted on
+                    the last close of the descriptor.
+
+     EV_RECEIPT     This flag is useful for making bulk changes to a kqueue
+                    without draining any pending events. When passed as input,
+                    it forces EV_ERROR to always be returned.  When a filter
+                    is successfully added. The data field will be zero.
+
+     EV_ONESHOT     Causes the event to return only the first occurrence of
+                    the filter being triggered.  After the user retrieves the
+                    event from the kqueue, it is deleted.
+
+     EV_CLEAR       After the event is retrieved by the user, its state is
+                    reset.  This is useful for filters which report state
+                    transitions instead of the current state.  Note that some
+                    filters may automatically set this flag internally.
+
+     EV_EOF         Filters may set this flag to indicate filter-specific EOF
+                    condition.
+
+     EV_ERROR       See RETURN VALUES below.
+
+     The predefined system filters are listed below.  Arguments may be passed
+     to and from the filter via the fflags and data fields in the kevent
+     structure.
+
+     EVFILT_READ    Takes a file descriptor as the identifier, and returns
+                    whenever there is data available to read.  The behavior of
+                    the filter is slightly different depending on the
+descrip-tor descriptor tor type.
+
+                    Sockets
+                        Sockets which have previously been passed to listen()
+                        return when there is an incoming connection pending.
+                        data contains the size of the listen backlog.
+
+                        Other socket descriptors return when there is data to
+                        be read, subject to the SO_RCVLOWAT value of the
+                        socket buffer.  This may be overridden with a
+per-fil-ter per-filter ter low water mark at the time the filter is added by
+                        setting the NOTE_LOWAT flag in fflags, and specifying
+                        the new low water mark in data.  On return, data
+con-tains contains tains the number of bytes of protocol data available to read.
+
+                        If the read direction of the socket has shutdown, then
+                        the filter also sets EV_EOF in flags, and returns the
+                        socket error (if any) in fflags.  It is possible for
+                        EOF to be returned (indicating the connection is gone)
+                        while there is still data pending in the socket
+                        buffer.
+
+                    Vnodes
+                        Returns when the file pointer is not at the end of
+                        file.  data contains the offset from current position
+                        to end of file, and may be negative.
+
+                    Fifos, Pipes
+                        Returns when the there is data to read; data contains
+                        the number of bytes available.
+
+                        When the last writer disconnects, the filter will set
+                        EV_EOF in flags.  This may be cleared by passing in
+                        EV_CLEAR, at which point the filter will resume wait-ing
+waiting ing for data to become available before returning.
+
+     EVFILT_WRITE   Takes a file descriptor as the identifier, and returns
+                    whenever it is possible to write to the descriptor.  For
+                    sockets, pipes and fifos, data will contain the amount of
+                    space remaining in the write buffer.  The filter will set
+                    EV_EOF when the reader disconnects, and for the fifo case,
+                    this may be cleared by use of EV_CLEAR.  Note that this
+                    filter is not supported for vnodes.
+
+                    For sockets, the low water mark and socket error handling
+                    is identical to the EVFILT_READ case.
+
+     EVFILT_AIO     This filter is currently unsupported.
+
+     EVFILT_VNODE   Takes a file descriptor as the identifier and the events
+                    to watch for in fflags, and returns when one or more of
+                    the requested events occurs on the descriptor.  The events
+                    to monitor are:
+
+                    NOTE_DELETE    The unlink() system call was called on the
+                                   file referenced by the descriptor.
+
+                    NOTE_WRITE     A write occurred on the file referenced by
+                                   the descriptor.
+
+                    NOTE_EXTEND    The file referenced by the descriptor was
+                                   extended.
+
+                    NOTE_ATTRIB    The file referenced by the descriptor had
+                                   its attributes changed.
+
+                    NOTE_LINK      The link count on the file changed.
+
+                    NOTE_RENAME    The file referenced by the descriptor was
+                                   renamed.
+
+                    NOTE_REVOKE    Access to the file was revoked via
+                                   revoke(2) or the underlying fileystem was
+                                   unmounted.
+
+                    On return, fflags contains the events which triggered the
+                    filter.
+
+     EVFILT_PROC    Takes the process ID to monitor as the identifier and the
+                    events to watch for in fflags, and returns when the
+                    process performs one or more of the requested events.  If
+                    a process can normally see another process, it can attach
+                    an event to it.  The events to monitor are:
+
+                    NOTE_EXIT
+                       The process has exited.
+
+                    NOTE_FORK
+                       The process created a child process via fork(2) or
+sim-ilar similar ilar call.
+
+                    NOTE_EXEC
+                       The process executed a new process via execve(2) or
+                       similar call.
+
+                    NOTE_SIGNAL
+                       The process was sent a signal. Status can be checked
+                       via waitpid(2) or similar call.
+
+                    NOTE_REAP
+                       The process was reaped by the parent via wait(2) or
+                       similar call.
+
+                    On return, fflags contains the events which triggered the
+                    filter.
+
+     EVFILT_SIGNAL  Takes the signal number to monitor as the identifier and
+                    returns when the given signal is delivered to the process.
+                    This coexists with the signal() and sigaction() facili-ties,
+facilities, ties, and has a lower precedence.  The filter will record all
+attempts to deliver a signal to a process, even if the signal has been marked as
+SIG_IGN.  Event notification happens after normal signal delivery processing.
+data returns the number of times the signal has occurred since the last call to
+kevent().  This filter automatically sets the EV_CLEAR flag internally.
+
+     EVFILT_TIMER   This filter is currently unsupported.
+
+RETURN VALUES
+     The kqueue() system call creates a new kernel event queue and returns a
+     file descriptor.  If there was an error creating the kernel event queue,
+     a value of -1 is returned and errno set.
+
+     The kevent() system call returns the number of events placed in the
+     eventlist, up to the value given by nevents.  If an error occurs while
+     processing an element of the changelist and there is enough room in the
+     eventlist, then the event will be placed in the eventlist with EV_ERROR
+     set in flags and the system error in data.  Otherwise, -1 will be
+     returned, and errno will be set to indicate the error condition.  If the
+     time limit expires, then kevent() returns 0.
+
+ERRORS
+     The kqueue() system call fails if:
+
+     [ENOMEM]           The kernel failed to allocate enough memory for the
+                        kernel queue.
+
+     [EMFILE]           The per-process descriptor table is full.
+
+     [ENFILE]           The system file table is full.
+
+     The kevent() system call fails if:
+
+     [EACCES]           The process does not have permission to register a
+                        filter.
+
+     [EFAULT]           There was an error reading or writing the kevent
+                        structure.
+
+     [EBADF]            The specified descriptor is invalid.
+
+     [EINTR]            A signal was delivered before the timeout expired and
+                        before any events were placed on the kqueue for
+                        return.
+
+     [EINVAL]           The specified time limit or filter is invalid.
+
+     [ENOENT]           The event could not be found to be modified or
+                        deleted.
+
+     [ENOMEM]           No memory was available to register the event.
+
+     [ESRCH]            The specified process to attach to does not exist.
+
+SEE ALSO
+     aio_error(2), aio_read(2), aio_return(2), read(2), select(2),
+     sigaction(2), write(2), signal(3)
+
+HISTORY
+     The kqueue() and kevent() system calls first appeared in FreeBSD 4.1.
+
+AUTHORS
+     The kqueue() system and this manual page were written by Jonathan Lemon
+     <jlemon@FreeBSD.org>.
+
+BUGS
+     Not all filesystem types support kqueue-style notifications.  And even
+     some that do, like some remote filesystems, may only support a subset of
+     the notification semantics described here.
+
+
+*/

--- a/includes/PollMultiplexer.hpp
+++ b/includes/PollMultiplexer.hpp
@@ -22,6 +22,7 @@ protected:
 private:
   typedef std::vector<struct pollfd> PollFdVec;
   typedef std::vector<struct pollfd>::iterator PollFdIt;
+  typedef std::vector<struct pollfd>::const_iterator ConstPollFdIt;
 
   PollFdVec pfds;
 

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -90,3 +90,4 @@ std::string trim(const std::string &s);
 
 // convert string to number
 size_t convert_str_to_size(const std::string &num_str);
+size_t parse_hex(const std::string &s);

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -87,3 +87,6 @@ void logfd(LogLevel level, const std::string &prefix, int fd);
 std::string trim_left(const std::string &s);
 std::string trim_right(const std::string &s);
 std::string trim(const std::string &s);
+
+// convert string to number
+size_t convert_str_to_size(const std::string &num_str);

--- a/includes/types.hpp
+++ b/includes/types.hpp
@@ -18,3 +18,6 @@ typedef ConfigMap::iterator ConfigIt;
 typedef ConfigMap::const_iterator ConstConfigIt;
 typedef LocationMap::iterator LocationIt;
 typedef LocationMap::const_iterator ConstLocationIt;
+
+typedef StrToStrMap::iterator StrToStrMapIt;
+typedef StrToStrMap::const_iterator ConstStrToStrMapIt;

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -6,12 +6,12 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/18 15:47:21 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/24 21:03:22 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/24 21:20:44 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Utils.hpp"
-#include <cstdint>
+#include <limits>
 
 int print_error_message(const std::string &message) {
   std::cerr << "Error: " << message << std::endl;
@@ -146,7 +146,7 @@ size_t convert_str_to_size(const std::string &num_str) {
     return val;
   }
   if ((endptr[0] == 'M' || endptr[0] == 'm') && endptr[1] == '\0') {
-    if (val > SIZE_MAX / 1048576) {
+    if (val > std::numeric_limits<std::size_t>::max() / 1048576) {
       throw std::runtime_error("Overflow during conversion: " + num_str);
     }
     return val * 1048576;

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -6,11 +6,12 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/18 15:47:21 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/24 15:58:15 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/24 21:03:22 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Utils.hpp"
+#include <cstdint>
 
 int print_error_message(const std::string &message) {
   std::cerr << "Error: " << message << std::endl;

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/18 15:47:21 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/22 15:22:42 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/24 15:58:15 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,7 +81,7 @@ std::string read_file(const std::string &file_path) {
 //     return "application/octet-stream";
 // }
 
-LogLevel current_log_level = LOG_FUNC;
+LogLevel current_log_level = LOG_INFO;
 std::ofstream debug_log("debug.log");
 
 void log(LogLevel level, const std::string &message) {
@@ -131,4 +131,24 @@ std::string trim_right(const std::string &s) {
 std::string trim(const std::string &s) {
   std::string trimmed = trim_right(s);
   return trim_left(trimmed);
+}
+
+size_t convert_str_to_size(const std::string &num_str) {
+  char *endptr;
+  errno = 0;
+
+  unsigned long val = std::strtoul(num_str.c_str(), &endptr, 10);
+  if (errno != 0 || endptr == num_str.c_str()) {
+    throw std::runtime_error("Invalid string to convert to number: " + num_str);
+  }
+  if (*endptr == '\0') {
+    return val;
+  }
+  if ((endptr[0] == 'M' || endptr[0] == 'm') && endptr[1] == '\0') {
+    if (val > SIZE_MAX / 1048576) {
+      throw std::runtime_error("Overflow during conversion: " + num_str);
+    }
+    return val * 1048576;
+  }
+  throw std::runtime_error("Invalid suffix in number: " + num_str);
 }

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/18 15:47:21 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/24 21:20:44 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/26 02:06:36 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -134,22 +134,33 @@ std::string trim(const std::string &s) {
   return trim_left(trimmed);
 }
 
-size_t convert_str_to_size(const std::string &num_str) {
+size_t convert_str_to_size(const std::string &s) {
   char *endptr;
   errno = 0;
 
-  unsigned long val = std::strtoul(num_str.c_str(), &endptr, 10);
-  if (errno != 0 || endptr == num_str.c_str()) {
-    throw std::runtime_error("Invalid string to convert to number: " + num_str);
+  unsigned long val = std::strtoul(s.c_str(), &endptr, 10);
+  if (errno != 0 || endptr == s.c_str()) {
+    throw std::runtime_error("Invalid string to convert to number: " + s);
   }
   if (*endptr == '\0') {
     return val;
   }
   if ((endptr[0] == 'M' || endptr[0] == 'm') && endptr[1] == '\0') {
     if (val > std::numeric_limits<std::size_t>::max() / 1048576) {
-      throw std::runtime_error("Overflow during conversion: " + num_str);
+      throw std::runtime_error("Overflow during conversion: " + s);
     }
     return val * 1048576;
   }
-  throw std::runtime_error("Invalid suffix in number: " + num_str);
+  throw std::runtime_error("Invalid suffix in number: " + s);
+}
+
+size_t parse_hex(const std::string &s) {
+  char *endptr;
+  errno = 0;
+
+  unsigned long val = std::strtoul(s.c_str(), &endptr, 16);
+  if (errno != 0 || endptr == s.c_str() || *endptr != '\0') {
+    throw std::runtime_error("Invalid chunk-size: " + s);
+  }
+  return val;
 }

--- a/srcs/event/EpollMultiplexer.cpp
+++ b/srcs/event/EpollMultiplexer.cpp
@@ -12,21 +12,146 @@ Multiplexer &EpollMultiplexer::get_instance() {
   return *Multiplexer::instance;
 }
 
-void EpollMultiplexer::run() { LOG_DEBUG_FUNC(); }
+void EpollMultiplexer::run() {
+  LOG_DEBUG_FUNC();
 
-void EpollMultiplexer::add_to_read_fds(int fd) { (void)fd; }
-void EpollMultiplexer::remove_from_read_fds(int fd) { (void)fd; }
-void EpollMultiplexer::add_to_write_fds(int fd) { (void)fd; }
-void EpollMultiplexer::remove_from_write_fds(int fd) { (void)fd; }
+  static const int max_user_watches = 3599293;
+  int size = 16; // num of fd; expect to monitor; not upper limit
+  epfd = epoll_create(size);
+  if (epfd == -1) {
+    throw std::runtime_error("epoll_create");
+  }
+  std::vector<struct epoll_event> evlist;
+  initialize_fds();
+  while (true) {
+    evlist.resize(size);
+    int nfd = epoll_wait(epfd, evlist.data(), evlist.size(), 0);
+    if (nfd == -1) {
+      if (errno == EINTR) { // (TLPI Section 21.5)
+        log(LOG_INFO, "epoll_wait() is stopped by a signal");
+        continue;
+      }
+      throw std::runtime_error("epoll_wait");
+    }
+    for (int i = 0; i < nfd; ++i) {
+      // TODO: EPOLLIN, EPOLLOUT,  EPOLLHUP, EPOLLERR をcheckするべき?
+      // EPOLLERRはthe other end of a FIFOのcloseやterminal hangupで起きる
+      // EPOLLERR はwebservに関係あるか？
+      process_event(evlist[i].data.fd, is_readable(evlist[i]),
+                    is_writable(evlist[i]));
+    }
+    if (nfd == size && size * 2 < max_user_watches) {
+      size *= 2;
+    }
+  }
+}
 
-bool EpollMultiplexer::is_readable(int fd) {
-  (void)fd;
-  return true;
+void EpollMultiplexer::add_to_read_fds(int fd) {
+  LOG_DEBUG_FUNC_FD(fd);
+
+  struct epoll_event ev;
+  ev.events = is_in_write_fds(fd) ? EPOLLIN | EPOLLOUT : EPOLLIN;
+  ev.data.fd = fd;
+
+  if (epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev) == -1) {
+    if (errno != EEXIST) {
+      logfd(LOG_ERROR, "failed to list fd in read monitor: ", fd);
+      return;
+    }
+    logfd(LOG_WARNING, "fd already under monitor: ", fd);
+    if (epoll_ctl(epfd, EPOLL_CTL_MOD, fd, &ev) == -1) {
+      logfd(LOG_ERROR, "failed to list fd in read monitor: ", fd);
+      return;
+    }
+  }
+  read_fds.insert(fd);
 }
-bool EpollMultiplexer::is_writable(int fd) {
-  (void)fd;
-  return true;
+
+void EpollMultiplexer::remove_from_read_fds(int fd) {
+  LOG_DEBUG_FUNC_FD(fd);
+
+  struct epoll_event ev;
+  ev.events = 0;
+  ev.data.fd = fd;
+
+  if (epoll_ctl(epfd, EPOLL_CTL_DEL, fd, &ev) == -1) {
+    if (errno != ENOENT) {
+      logfd(LOG_ERROR, "failed to delete fd: ", fd);
+      return;
+    }
+    logfd(LOG_WARNING, "fd already erased: ", fd);
+  }
+  read_fds.erase(fd);
+  write_fds.erase(fd);
 }
+
+void EpollMultiplexer::add_to_write_fds(int fd) {
+  LOG_DEBUG_FUNC_FD(fd);
+
+  struct epoll_event ev;
+  ev.data.fd = fd;
+  ev.events = EPOLLIN | EPOLLOUT;
+
+  if (epoll_ctl(epfd, EPOLL_CTL_MOD, fd, &ev) == -1) {
+
+    if (errno != ENOENT) {
+      logfd(LOG_ERROR, "failed to list fd in write monitor: ", fd);
+      return;
+    }
+    logfd(LOG_WARNING, "fd not in read monitor. Adding it now: ", fd);
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev) == -1) {
+      logfd(LOG_ERROR, "failed to list fd in both monitor: ", fd);
+      return;
+    }
+    read_fds.insert(fd);
+  }
+  write_fds.insert(fd);
+}
+
+void EpollMultiplexer::remove_from_write_fds(int fd) {
+  LOG_DEBUG_FUNC_FD(fd);
+
+  struct epoll_event ev;
+  ev.data.fd = fd;
+  ev.events = EPOLLIN;
+
+  if (epoll_ctl(epfd, EPOLL_CTL_MOD, fd, &ev) == -1) {
+
+    if (errno != ENOENT) {
+      logfd(LOG_ERROR, "failed to delist fd in write monitor: ", fd);
+      return;
+    }
+    logfd(LOG_WARNING, "fd not in read monitor. Adding it now: ", fd);
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev) == -1) {
+      logfd(LOG_ERROR, "failed to list fd in read monitor: ", fd);
+      return;
+    }
+    read_fds.insert(fd);
+  }
+  write_fds.erase(fd);
+}
+
+bool EpollMultiplexer::is_readable(struct epoll_event &ev) const {
+  return ev.events & EPOLLIN;
+}
+
+bool EpollMultiplexer::is_writable(struct epoll_event &ev) const {
+  return ev.events & EPOLLOUT;
+}
+
+bool EpollMultiplexer::is_in_read_fds(int fd) const {
+  return read_fds.find(fd) != read_fds.end();
+}
+
+bool EpollMultiplexer::is_in_write_fds(int fd) const {
+  return write_fds.find(fd) != write_fds.end();
+}
+
+// EPOLLIN ではなく、buf超過のときにはerror handling必要かも？
+// bool EpollMultiplexer::has_more_than_max_to_read(struct epoll_event &ev)
+// const {
+//   return ev.events & (EPOLLHUP | EPOLLERR);
+// }
 
 EpollMultiplexer::EpollMultiplexer() {}
 

--- a/srcs/event/EpollMultiplexer.cpp
+++ b/srcs/event/EpollMultiplexer.cpp
@@ -5,15 +5,14 @@
 
 Multiplexer &EpollMultiplexer::get_instance() {
   if (!Multiplexer::instance) {
+    log(LOG_INFO, "EpollMultiplexer::get_instance()");
     Multiplexer::instance = new EpollMultiplexer();
     std::atexit(Multiplexer::delete_instance);
   }
   return *Multiplexer::instance;
 }
 
-void EpollMultiplexer::run() {
-  LOG_DEBUG_FUNC();
-}
+void EpollMultiplexer::run() { LOG_DEBUG_FUNC(); }
 
 void EpollMultiplexer::add_to_read_fds(int fd) { (void)fd; }
 void EpollMultiplexer::remove_from_read_fds(int fd) { (void)fd; }

--- a/srcs/event/KqueueMultiplexer.cpp
+++ b/srcs/event/KqueueMultiplexer.cpp
@@ -8,6 +8,7 @@
 
 Multiplexer &KqueueMultiplexer::get_instance() {
   if (!Multiplexer::instance) {
+    log(LOG_INFO, "KqueueMultiplexer::get_instance()");
     Multiplexer::instance = new KqueueMultiplexer();
     std::atexit(Multiplexer::delete_instance);
   }

--- a/srcs/event/KqueueMultiplexer.cpp
+++ b/srcs/event/KqueueMultiplexer.cpp
@@ -2,6 +2,9 @@
 #include "Utils.hpp"
 #include <cstdlib>
 #include <iostream>
+#include <sys/event.h>
+#include <sys/time.h>
+#include <sys/types.h>
 
 Multiplexer &KqueueMultiplexer::get_instance() {
   if (!Multiplexer::instance) {
@@ -11,21 +14,65 @@ Multiplexer &KqueueMultiplexer::get_instance() {
   return *Multiplexer::instance;
 }
 
-void KqueueMultiplexer::run() { LOG_DEBUG_FUNC(); }
+void KqueueMultiplexer::run() {
+  LOG_DEBUG_FUNC();
+  int kq = kqueue();
+  int size = 16;
 
-void KqueueMultiplexer::add_to_read_fds(int fd) { (void)fd; }
-void KqueueMultiplexer::remove_from_read_fds(int fd) { (void)fd; }
-void KqueueMultiplexer::add_to_write_fds(int fd) { (void)fd; }
-void KqueueMultiplexer::remove_from_write_fds(int fd) { (void)fd; }
-
-bool KqueueMultiplexer::is_readable(int fd) {
-  (void)fd;
-  return true;
+  initialize_fds();
+  while (true) {
+    event_list.resize(size);
+    int nev = kevent(kq, change_list.data(), change_list.size(),
+                     event_list.data(), event_list.size(), 0);
+    if (nev == -1) {
+      log(LOG_ERROR, "kevent() failed: ");
+      continue;
+    }
+    change_list.clear();
+    for (int i = 0; i < nev; ++i) {
+      process_event(event_list[i].ident, is_readable(event_list[i]),
+                    is_writable(event_list[i]));
+    }
+    if (nev == size) {
+      size *= 2;
+    }
+  }
 }
 
-bool KqueueMultiplexer::is_writable(int fd) {
-  (void)fd;
-  return true;
+void KqueueMultiplexer::add_to_read_fds(int fd) {
+  LOG_DEBUG_FUNC_FD(fd);
+  struct kevent ev;
+  EV_SET(&ev, fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, 0);
+  change_list.push_back(ev);
+}
+
+void KqueueMultiplexer::remove_from_read_fds(int fd) {
+  LOG_DEBUG_FUNC_FD(fd);
+  struct kevent ev;
+  EV_SET(&ev, fd, EVFILT_READ, EV_DELETE, 0, 0, 0);
+  change_list.push_back(ev);
+}
+
+void KqueueMultiplexer::add_to_write_fds(int fd) {
+  LOG_DEBUG_FUNC_FD(fd);
+  struct kevent ev;
+  EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, 0);
+  change_list.push_back(ev);
+}
+
+void KqueueMultiplexer::remove_from_write_fds(int fd) {
+  LOG_DEBUG_FUNC_FD(fd);
+  struct kevent ev;
+  EV_SET(&ev, fd, EVFILT_WRITE, EV_DELETE, 0, 0, 0);
+  change_list.push_back(ev);
+}
+
+bool KqueueMultiplexer::is_readable(struct kevent &ev) const {
+  return (ev.filter == EVFILT_READ);
+}
+
+bool KqueueMultiplexer::is_writable(struct kevent &ev) const {
+  return (ev.filter == EVFILT_WRITE);
 }
 
 KqueueMultiplexer::KqueueMultiplexer() {}

--- a/srcs/event/Multiplexer.cpp
+++ b/srcs/event/Multiplexer.cpp
@@ -15,7 +15,6 @@
 Multiplexer *Multiplexer::instance = 0;
 
 Multiplexer &Multiplexer::get_instance() {
-  return KqueueMultiplexer::get_instance();
 #if defined(__linux__)
   return EpollMultiplexer::get_instance();
 #elif defined(__APPLE__) || defined(__MACH__)

--- a/srcs/event/Multiplexer.cpp
+++ b/srcs/event/Multiplexer.cpp
@@ -15,11 +15,11 @@
 Multiplexer *Multiplexer::instance = 0;
 
 Multiplexer &Multiplexer::get_instance() {
-  return SelectMultiplexer::get_instance();
+  return KqueueMultiplexer::get_instance();
 #if defined(__linux__)
   return EpollMultiplexer::get_instance();
 #elif defined(__APPLE__) || defined(__MACH__)
-  return SelectMultiplexer::get_instance();
+  return KqueueMultiplexer::get_instance();
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)
   return KqueueMultiplexer::get_instance();
 #elif defined(HAS_POLL)

--- a/srcs/event/PollMultiplexer.cpp
+++ b/srcs/event/PollMultiplexer.cpp
@@ -9,6 +9,7 @@
 
 Multiplexer &PollMultiplexer::get_instance() {
   if (!Multiplexer::instance) {
+    log(LOG_INFO, "PollMultiplexer::get_instance()");
     Multiplexer::instance = new PollMultiplexer();
     std::atexit(Multiplexer::delete_instance);
   }

--- a/srcs/event/SelectMultiplexer.cpp
+++ b/srcs/event/SelectMultiplexer.cpp
@@ -9,6 +9,7 @@
 
 Multiplexer &SelectMultiplexer::get_instance() {
   if (!Multiplexer::instance) {
+    log(LOG_INFO, "SelectMultiplexer::get_instance()");
     Multiplexer::instance = new SelectMultiplexer();
     std::atexit(Multiplexer::delete_instance);
   }

--- a/srcs/http/HttpRequest.cpp
+++ b/srcs/http/HttpRequest.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:37:05 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/22 16:04:48 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/22 16:46:08 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,10 @@ HttpRequest::~HttpRequest() {}
 
 void HttpRequest::handle_http_request() {
   LOG_DEBUG_FUNC();
+  if (status_code != 0) {
+    response.generate_error_response(status_code);
+    return;
+  }
 
   // std::string method, path, version;
   // if (!parse_http_request(buffer, method, path, version)) {

--- a/srcs/http/HttpRequest.cpp
+++ b/srcs/http/HttpRequest.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:37:05 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/22 16:46:08 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/24 15:51:48 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,20 +16,40 @@
 #include "Server.hpp"
 #include "Utils.hpp"
 
+const size_t HttpRequest::k_default_max_body = 104857600;
+
 // server fd 経由で, server_config, locations_configs を取得
 HttpRequest::HttpRequest(int server_fd, HttpResponse &httpResponse)
-    : response(httpResponse), status_code(0) {
+    : response(httpResponse), status_code(0),
+      max_body_size(k_default_max_body) {
   Server *server = Multiplexer::get_instance().get_server_from_map(server_fd);
   if (!server) {
     throw std::runtime_error("server not found by HttpRequest");
   }
   this->server_config = server->get_config();
   this->location_configs = server->get_locations();
+
+  // TODO: configの不正値検出は最初のconfig読み込みにうつすかも（一旦ここ）
+  try {
+    load_max_body_size();
+  } catch (const std::exception &e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+  }
 }
 
 HttpRequest::~HttpRequest() {}
 
-// HttpRequest::HttpRequest(const std::map<std::string, std::vector<std::string>
+void HttpRequest::load_max_body_size() {
+  ConstConfigIt it = server_config.find("client_max_body_size");
+  if (it != server_config.end()) {
+    std::string max_size_str = it->second.front();
+    max_body_size = convert_str_to_size(max_size_str);
+  }
+  logfd(LOG_DEBUG, "client_max_body_size loaded: ", max_body_size);
+}
+
+// HttpRequest::HttpRequest(const std::map<std::string,
+// std::vector<std::string>
 // >& config, const std::map<std::string, std::map<std::string,
 // std::vector<std::string> > >&  location_config) {
 //     this->server_configs = config;
@@ -114,7 +134,8 @@ ConfigMap HttpRequest::get_location_config(const std::string &path) {
   // 最もマッチする `location` を探す
   std::string best_match = "/";
   //   std::map<std::string,
-  //            std::map<std::string, std::vector<std::string>>>::const_iterator
+  //            std::map<std::string,
+  //            std::vector<std::string>>>::const_iterator
 
   ConstLocationIt best_match_it = location_configs.find("/");
 
@@ -195,7 +216,8 @@ void HttpRequest::handle_file_request(const std::string &file_path) {
   std::ostringstream buffer;
   buffer << file.rdbuf();
   std::string file_content = buffer.str();
-  // HttpResponse::send_response(client_socket, 200, file_content, "text/html");
+  // HttpResponse::send_response(client_socket, 200, file_content,
+  // "text/html");
   response.generate_response(200, file_content, "text/html");
 }
 
@@ -299,7 +321,8 @@ void HttpRequest::handle_post_request(const std::string &request,
     // HttpResponse::send_response(client_socket, 201, body, "text/plain");
     response.generate_response(201, body, "text/plain");
   } else {
-    // アップロードできない場合は通常のresource取得になるらしい (GETと同様処理)
+    // アップロードできない場合は通常のresource取得になるらしい
+    // (GETと同様処理)
     handle_get_request(path);
   }
 }
@@ -383,8 +406,8 @@ bool HttpRequest::is_cgi_request(const std::string &path) {
     }
   }
   return false;
-  // return (extension == ".cgi" || extension == ".php" || extension == ".py" ||
-  // extension == ".pl"); → confファイルで指示あり？
+  // return (extension == ".cgi" || extension == ".php" || extension == ".py"
+  // || extension == ".pl"); → confファイルで指示あり？
 }
 
 void HttpRequest::handle_cgi_request(const std::string &cgi_path) {
@@ -461,6 +484,20 @@ void HttpRequest::set_status_code(int status) { status_code = status; }
 
 int HttpRequest::get_status_code() const { return status_code; }
 
+size_t HttpRequest::get_max_body_size() const { return max_body_size; }
+
+bool HttpRequest::is_in_headers(const std::string &key) const {
+  return (headers.find(key) != headers.end());
+}
+
+std::string HttpRequest::get_value_from_headers(const std::string &key) const {
+  ConstStrToStrMapIt it = headers.find(key);
+  if (it != headers.end()) {
+    return it->second;
+  }
+  return "";
+}
+
 bool HttpRequest::add_header(std::string &key, std::string &value) {
   if (headers.find(key) != headers.end()) {
     return false;
@@ -484,8 +521,8 @@ HttpRequest &HttpRequest::operator=(const HttpRequest &other) {
 }
 
 // bool HttpRequest::parse_http_request(const std::string &request,
-//                                      std::string &method, std::string &path,
-//                                      std::string &version) {
+//                                      std::string &method, std::string
+//                                      &path, std::string &version) {
 //   std::istringstream request_stream(request);
 //   if (!(request_stream >> method >> path >> version)) {
 //     return false;

--- a/srcs/http/HttpRequestParser.cpp
+++ b/srcs/http/HttpRequestParser.cpp
@@ -2,6 +2,9 @@
 #include "Utils.hpp"
 #include <set>
 
+static const char *unreserved_chars = "-._~";
+static const char *reserved_chars = ":/?#[]@!$&'()*+,;=";
+
 const size_t HttpRequestParser::k_max_request_line = 10000;
 const size_t HttpRequestParser::k_max_request_target = 2048;
 
@@ -207,8 +210,15 @@ bool HttpRequestParser::validate_request_content() {
     return false;
   }
 
-  // TODO: Request url が NG文字を含む
-  // request.set_status_code(400);
+  for (size_t i = 0; i < request.path.size(); ++i) {
+    char c = request.path.at(i);
+    if (!std::isdigit(c) && !std::isalpha(c) &&
+        !std::strchr(unreserved_chars, c) && !std::strchr(reserved_chars, c)) {
+      log(LOG_DEBUG, std::string("Invalid character in target: '") + c + "'");
+      request.set_status_code(400);
+      return false;
+    }
+  }
 
   if (request.path.size() > k_max_request_target) {
     log(LOG_DEBUG, "Request-target is too long");

--- a/srcs/http/HttpResponse.cpp
+++ b/srcs/http/HttpResponse.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:37:08 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/22 16:04:38 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/22 16:45:31 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,6 @@ std::string HttpResponse::get_next_response() {
 
 void HttpResponse::pop_response() {
   LOG_DEBUG_FUNC();
-
   response_queue.pop();
 }
 
@@ -103,6 +102,18 @@ void HttpResponse::generate_error_response(int status_code,
 
   push_response(response.str());
   // send(client_socket, response.str().c_str(), response.str().size(), 0);
+}
+
+void HttpResponse::generate_error_response(int status_code) {
+  LOG_DEBUG_FUNC();
+  std::ostringstream response;
+  const std::string &message = get_status_message(status_code);
+  response << "HTTP/1.1 " << status_code << " " << message << "\r\n";
+  response << "Content-Length: " << message.size() << "\r\n";
+  response << "Content-Type: text/plain\r\n\r\n";
+  response << message;
+
+  push_response(response.str());
 }
 
 // 未実装


### PR DESCRIPTION
## 概要
kqueueによるI/O多重化機能を追加 close #26
Linux環境ではkqueueをコンパイルできないため、ビルドエラーを修正

epollによるI/O多重化機能を追加 close #24

## 課題
select(), poll(), epoll(), kqueue() などのI/O多重化関数が `EINTR` 以外の理由で `-1` を返した場合、
プログラムを終了すべきか、継続してリトライすべきか理解があやふやな状態なこと ref #28
-> 確認してあとで統一する