### PR TITLE
IOエラー処理の統一 & fd上限の導入  (#28, #35)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,4 +56,9 @@ run: $(NAME)
 	./$(NAME) config/valid/multiple_servers.conf
 	@echo "== Tests Completed =="
 
-.PHONY: all clean fclean re run
+test:
+	@echo "== Running Tests  =="
+	siege -c 10 -r 5 --time=10S --log=/tmp/siege.log http://localhost:8080
+	@echo "== Tests Completed =="
+
+.PHONY: all clean fclean re run test

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -10,7 +10,8 @@ class Server;
 enum IOStatus {
   IO_SUCCESS,  // 処理完了
   IO_CONTINUE, // 作業継続
-  IO_FAILED    // エラーまたはクライアント切断
+  IO_CLOSED,   // client disconnectd (recv == 0)
+  IO_ERROR     // I/O system call 失敗 (recv/send == -1)
 };
 
 class Client {

--- a/includes/EpollMultiplexer.hpp
+++ b/includes/EpollMultiplexer.hpp
@@ -2,8 +2,10 @@
 
 #include "Multiplexer.hpp"
 #include <set>
-#include <sys/epoll.h>
 #include <vector>
+#ifdef __linux__
+#include <sys/epoll.h>
+#endif
 
 /**
  * epoll を用いたI/Oの多重化

--- a/srcs/event/EpollMultiplexer.cpp
+++ b/srcs/event/EpollMultiplexer.cpp
@@ -14,7 +14,6 @@ Multiplexer &EpollMultiplexer::get_instance() {
 
 void EpollMultiplexer::run() {
   LOG_DEBUG_FUNC();
-
   static const int max_user_watches = 3599293;
   int size = 16; // num of fd; expect to monitor; not upper limit
   epfd = epoll_create(size);
@@ -23,20 +22,20 @@ void EpollMultiplexer::run() {
   }
   std::vector<struct epoll_event> evlist;
   initialize_fds();
+
   while (true) {
     evlist.resize(size);
     int nfd = epoll_wait(epfd, evlist.data(), evlist.size(), 0);
     if (nfd == -1) {
-      if (errno == EINTR) { // (TLPI Section 21.5)
-        log(LOG_INFO, "epoll_wait() is stopped by a signal");
+      if (errno == EINTR) {
         continue;
       }
-      throw std::runtime_error("epoll_wait");
+      throw std::runtime_error("epoll_wait() failed");
     }
+
+    logfd(LOG_DEBUG, "epoll_wait() returned: ", nfd);
+
     for (int i = 0; i < nfd; ++i) {
-      // TODO: EPOLLIN, EPOLLOUT,  EPOLLHUP, EPOLLERR をcheckするべき?
-      // EPOLLERRはthe other end of a FIFOのcloseやterminal hangupで起きる
-      // EPOLLERR はwebservに関係あるか？
       process_event(evlist[i].data.fd, is_readable(evlist[i]),
                     is_writable(evlist[i]));
     }
@@ -146,12 +145,6 @@ bool EpollMultiplexer::is_in_read_fds(int fd) const {
 bool EpollMultiplexer::is_in_write_fds(int fd) const {
   return write_fds.find(fd) != write_fds.end();
 }
-
-// EPOLLIN ではなく、buf超過のときにはerror handling必要かも？
-// bool EpollMultiplexer::has_more_than_max_to_read(struct epoll_event &ev)
-// const {
-//   return ev.events & (EPOLLHUP | EPOLLERR);
-// }
 
 EpollMultiplexer::EpollMultiplexer() {}
 

--- a/srcs/event/KqueueMultiplexer.cpp
+++ b/srcs/event/KqueueMultiplexer.cpp
@@ -17,11 +17,15 @@ Multiplexer &KqueueMultiplexer::get_instance() {
 
 void KqueueMultiplexer::run() {
   LOG_DEBUG_FUNC();
+  static const int max_kqueue_events = 16384;
   int kq = kqueue();
   int size = 16;
   initialize_fds();
 
   while (true) {
+    if (size >= max_kqueue_events) {
+      throw std::runtime_error("kqueue event list exceeds limit");
+    }
     event_list.resize(size);
     int nfd = kevent(kq, change_list.data(), change_list.size(),
                      event_list.data(), event_list.size(), 0);

--- a/srcs/event/PollMultiplexer.cpp
+++ b/srcs/event/PollMultiplexer.cpp
@@ -18,6 +18,7 @@ Multiplexer &PollMultiplexer::get_instance() {
 
 void PollMultiplexer::run() {
   LOG_DEBUG_FUNC();
+  static const int max_poll_events = 65536;
   pfds.reserve(get_num_servers());
   initialize_fds();
   if (pfds.empty()) {
@@ -25,6 +26,9 @@ void PollMultiplexer::run() {
   }
 
   while (true) {
+    if (pfds.size() >= max_poll_events) {
+      throw std::runtime_error("poll() fd count exceeds limit");
+    }
     int nfd = poll(pfds.data(), pfds.size(), 0);
     if (nfd == -1) {
       if (errno == EINTR) {

--- a/srcs/event/SelectMultiplexer.cpp
+++ b/srcs/event/SelectMultiplexer.cpp
@@ -21,6 +21,9 @@ void SelectMultiplexer::run() {
   initialize_fds();
 
   while (true) {
+    if (max_fd >= FD_SETSIZE) {
+      throw std::runtime_error("select() fd exceeds FD_SETSIZE");
+    }
     active_read_fds = read_fds;
     active_write_fds = write_fds;
     int nfd = select(max_fd + 1, &active_read_fds, &active_write_fds, 0, 0);

--- a/srcs/event/SelectMultiplexer.cpp
+++ b/srcs/event/SelectMultiplexer.cpp
@@ -19,15 +19,20 @@ Multiplexer &SelectMultiplexer::get_instance() {
 void SelectMultiplexer::run() {
   LOG_DEBUG_FUNC();
   initialize_fds();
+
   while (true) {
     active_read_fds = read_fds;
     active_write_fds = write_fds;
-    int ret = select(max_fd + 1, &active_read_fds, &active_write_fds, 0, 0);
-    std::cout << "Select returned: " << ret << "\n";
-    if (ret < 0 && errno != EINTR) {
-      log(LOG_ERROR, "select() failed: ");
-      continue;
+    int nfd = select(max_fd + 1, &active_read_fds, &active_write_fds, 0, 0);
+    if (nfd == -1) {
+      if (errno == EINTR) {
+        continue;
+      }
+      throw std::runtime_error("select() failed");
     }
+
+    logfd(LOG_DEBUG, "select() returned: ", nfd);
+
     for (int fd = 0; fd <= max_fd; ++fd) {
       process_event(fd, is_readable(fd), is_writable(fd));
     }

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/18 15:47:14 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/22 13:18:42 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/03/31 02:22:34 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,9 +16,24 @@
 #include "Utils.hpp"
 #include "types.hpp"
 
+static void free_resources(Multiplexer *multiplexer,
+                           std::vector<Server *> &servers) {
+  if (multiplexer) {
+    multiplexer->delete_instance(); // fd close & clientのdelete
+  }
+  for (size_t i = 0; i < servers.size(); i++) {
+    delete servers[i];
+  }
+  debug_log.close();
+}
+
 int main(int argc, char **argv) {
   if (argc != 2)
     return (print_error_message("need conf filename"));
+
+  Multiplexer *multiplexer = NULL;
+  std::vector<Server *> servers;
+
   try {
     Parse parser(argv[1]);
     ServerAndLocationConfigs server_location_configs;
@@ -26,21 +41,19 @@ int main(int argc, char **argv) {
     if (server_location_configs.empty())
       throw std::runtime_error("No valid server configurations found.");
 
-    Multiplexer &multiplexer = Multiplexer::get_instance();
-    std::vector<Server *> servers;
+    multiplexer = &Multiplexer::get_instance();
     for (size_t i = 0; i < server_location_configs.size(); i++)
       servers.push_back(new Server(server_location_configs[i].first,
                                    server_location_configs[i].second));
     for (size_t i = 0; i < servers.size(); i++)
       servers[i]->createSockets();
-    multiplexer.run();
-    multiplexer.delete_instance(); // fd close & clientのdelete
-    for (size_t i = 0; i < servers.size(); i++)
-      delete servers[i];
-    debug_log.close();
+
+    multiplexer->run();
+
+    free_resources(multiplexer, servers);
   } catch (const std::exception &e) {
     std::cerr << "Error: " << e.what() << std::endl;
-    debug_log.close();
+    free_resources(multiplexer, servers);
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;


### PR DESCRIPTION
### 概要

- IO_Statusの`IO_FAILED`を `IO_CLOSED` / `IO_ERROR` に分離し、切断とエラーを明確化
- 各Multiplexer（select/poll/kqueue/epoll）のエラー処理を統一化
- 各IO多重化関数に fd数の上限を設定

### 関連
- close #28
- close #35
