### PR TITLE
Connection: close/keep-alive 対応と graceful shutdown の実装

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -8,10 +8,16 @@
 class Server;
 
 enum IOStatus {
-  IO_CONTINUE, // 作業継続
-  IO_DONE,     // 処理完了: recv 次のrequest待ち, write 監視解除
-  IO_CLOSED,   // client disconnectd (recv == 0)
-  IO_ERROR     // I/O system call 失敗 (recv/send == -1)
+  IO_CONTINUE,        // 現状維持（read/write継続）
+  IO_READY_TO_WRITE,  // write監視をON
+  IO_WRITE_COMPLETE,  // write監視をOFF
+  IO_SHOULD_SHUTDOWN, // shutdown(fd, SHUT_WR)
+  IO_SHOULD_CLOSE     // close(fd)
+};
+
+enum ClientState {
+  CLIENT_ALIVE,      // 通常
+  CLIENT_HALF_CLOSED // SHUT_WR 済み; EOF or `Connection: close` 待ち
 };
 
 class Client {
@@ -23,15 +29,19 @@ public:
   IOStatus on_write();
 
 private:
-  int fd;                      // client fd
-  int server_fd;               // このclientが接続しているserver fd
-  HttpResponse response;       // responseの生成とqueue管理
-  HttpRequest request;         // header情報, body, contentLengthなどの管理
-  HttpRequestParser parser;    // header, bodyの解析管理
-  std::string response_buffer; // 現在送信中のbuffer
-  size_t response_sent;        // send済みのbytes数
+  int fd;                   // client fd
+  int server_fd;            // このclientが接続しているserver fd
+  HttpResponse response;    // responseの生成とqueue管理
+  HttpRequest request;      // header情報, body, contentLengthなどの管理
+  HttpRequestParser parser; // header, bodyの解析管理
 
-  bool on_parse();
+  ClientState client_state;
+  // std::string response_buffer; // 現在送信中のbuffer
+  ResponseEntry *current_entry; // 現在送信中のresponse entry;
+  size_t response_sent;         // send済みのbytes数
+
+  IOStatus on_parse();
+  IOStatus on_half_close();
   bool has_response() const;
 
   Client(const Client &other);

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -8,8 +8,8 @@
 class Server;
 
 enum IOStatus {
-  IO_SUCCESS,  // 処理完了
   IO_CONTINUE, // 作業継続
+  IO_DONE,     // 処理完了: recv 次のrequest待ち, write 監視解除
   IO_CLOSED,   // client disconnectd (recv == 0)
   IO_ERROR     // I/O system call 失敗 (recv/send == -1)
 };

--- a/includes/HttpRequest.hpp
+++ b/includes/HttpRequest.hpp
@@ -3,18 +3,20 @@
 /*                                                        :::      ::::::::   */
 /*   HttpRequest.hpp                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: koseki.yusuke <koseki.yusuke@student.42    +#+  +:+       +#+        */
+/*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:44:38 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/04/05 20:19:12 by koseki.yusu      ###   ########.fr       */
+/*   Updated: 2025/04/17 16:52:55 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #pragma once
 
+#include "ResponseTypes.hpp"
 #include "types.hpp"
 #include <algorithm>
 #include <dirent.h>
+#include <fcntl.h>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -26,7 +28,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <vector>
-#include <fcntl.h> 
 
 class HttpResponse;
 
@@ -55,6 +56,9 @@ public:
   ~HttpRequest();
   void handle_http_request();
 
+  ConnectionPolicy get_connection_policy() const;
+  void set_connection_policy(ConnectionPolicy policy);
+
   void set_status_code(int status);
   int get_status_code() const;
   void load_max_body_size();
@@ -73,6 +77,7 @@ public:
 
 private:
   HttpResponse &response;
+  ConnectionPolicy connection_policy;
   int status_code;
   std::string _root;
   size_t max_body_size;

--- a/includes/HttpRequestParser.hpp
+++ b/includes/HttpRequestParser.hpp
@@ -44,6 +44,8 @@ private:
   bool validate_request_content();
   bool validate_headers_content();
 
+  void determine_connection_policy();
+
   HttpRequestParser(const HttpRequestParser &other);
   HttpRequestParser &operator=(const HttpRequestParser &other);
 };

--- a/includes/HttpResponse.hpp
+++ b/includes/HttpResponse.hpp
@@ -6,40 +6,54 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:44:51 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/03/22 16:44:05 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/04/18 00:33:32 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #pragma once
 
+#include "ResponseTypes.hpp"
 #include <iostream>
 #include <queue>
 #include <sstream>
 #include <string>
 #include <sys/socket.h>
 
+struct ResponseEntry {
+  bool is_ready;         // 送信可能か
+  ConnectionPolicy conn; // 送信後の接続処理
+  std::string buffer;    // response
+};
+
 class HttpResponse {
 public:
   HttpResponse();
   ~HttpResponse();
 
-  bool has_next_response() const;
-  std::string get_next_response();
+  ResponseEntry *get_next_response();
   void pop_response();
+  bool has_next_response() const;
 
   void generate_custom_error_page(int status_code,
-                                  const std::string &error_page);
-  void generate_error_response(int status_code, const std::string &message);
-  void generate_error_response(int status_code);
+                                  const std::string &error_page,
+                                  ConnectionPolicy connection_policy);
+  void generate_error_response(int status_code, const std::string &message,
+                               ConnectionPolicy connection_policy);
+  void generate_error_response(int status_code,
+                               ConnectionPolicy connection_policy);
   void generate_response(int status_code, const std::string &content,
-                         const std::string &content_type);
-  void generate_redirect(int status_code, const std::string &new_location);
+                         const std::string &content_type,
+                         ConnectionPolicy connection_policy);
+  void generate_redirect(int status_code, const std::string &new_location,
+                         ConnectionPolicy conn);
 
 private:
-  std::queue<std::string> response_queue;
+  std::queue<ResponseEntry> response_queue;
 
-  void push_response(const std::string &response);
-  std::string get_status_message(int status_code);
+  void push_response(ConnectionPolicy connection_policy,
+                     const std::string &response);
+  const char *get_status_message(int status_code);
+  const char *to_connection_value(ConnectionPolicy conn) const;
 
   HttpResponse(const HttpResponse &other);
   HttpResponse &operator=(const HttpResponse &other);

--- a/includes/Multiplexer.hpp
+++ b/includes/Multiplexer.hpp
@@ -68,6 +68,7 @@ private:
   void accept_client(int server_fd);
   void read_from_client(int client_fd);
   void write_to_client(int client_fd);
+  void shutdown_write(int client_fd);
   void remove_client(int client_fd);
 
   // 代入禁止

--- a/includes/ResponseTypes.hpp
+++ b/includes/ResponseTypes.hpp
@@ -1,0 +1,8 @@
+// ResponseTypes.hpp
+#pragma once
+
+enum ConnectionPolicy {
+  CP_KEEP_ALIVE, // keep-alive中 かつ healthy
+  CP_WILL_CLOSE, // Connection: close 受信済み
+  CP_MUST_CLOSE  // graceful closeのプロセスに進む
+};

--- a/srcs/client/Client.cpp
+++ b/srcs/client/Client.cpp
@@ -5,11 +5,13 @@
 #include "Utils.hpp"
 #include <sstream>
 #include <stdexcept>
-#include <sys/socket.h>
+
+// TODO: timeout処理が必要 あとで
 
 Client::Client(int clientfd, int serverfd)
     : fd(clientfd), server_fd(serverfd), response(),
-      request(serverfd, response), parser(request), response_sent(0) {}
+      request(serverfd, response), parser(request), client_state(CLIENT_ALIVE),
+      response_sent(0) {}
 
 Client::~Client() {}
 
@@ -18,43 +20,64 @@ IOStatus Client::on_read() {
   const int buf_size = 1024;
   char buffer[buf_size];
   ssize_t bytes_read = recv(fd, buffer, sizeof(buffer), 0);
-  if (bytes_read == -1) {
-    return IO_ERROR; // 異常終了: client側でのexitを含む
-  }
-  if (bytes_read == 0) {
-    return IO_CLOSED; // 正常終了: client側でのclose()
+  if (bytes_read == -1 || bytes_read == 0) {
+    return IO_SHOULD_CLOSE;
   }
   parser.append_data(buffer, bytes_read);
-  // parse 成功時 (IO_DONE) は write fd の監視開始
-  return on_parse() ? IO_DONE : IO_CONTINUE;
+
+  if (client_state == CLIENT_HALF_CLOSED) {
+    return on_half_close();
+  }
+  return on_parse();
 }
 
 IOStatus Client::on_write() {
   LOG_DEBUG_FUNC();
-  if (!has_response()) {
-    return IO_DONE; // 送信可能なresponseがない
+  if (client_state == CLIENT_HALF_CLOSED || !has_response()) {
+    return IO_WRITE_COMPLETE;
   }
-  if (response_buffer.empty()) {
-    response_buffer = response.get_next_response();
+  if (!current_entry) {
+    current_entry = response.get_next_response();
     response_sent = 0;
   }
 
-  ssize_t bytes_sent = send(fd, response_buffer.c_str() + response_sent,
-                            response_buffer.size() - response_sent, 0);
+  ssize_t bytes_sent = send(fd, current_entry->buffer.c_str() + response_sent,
+                            current_entry->buffer.size() - response_sent, 0);
   if (bytes_sent == -1 || bytes_sent == 0) {
-    return IO_ERROR; // 異常終了 send() 失敗
+    return IO_SHOULD_CLOSE;
   }
 
   response_sent += bytes_sent;
-  if (response_sent >= response_buffer.size()) {
-    response_buffer.clear();
-    response.pop_response();
+  if (response_sent < current_entry->buffer.size()) {
+    return IO_CONTINUE; // 今回のsendで、response全体を送信できなかった
   }
-  // continue: write続行, done: write完了
-  return has_response() ? IO_CONTINUE : IO_DONE;
+
+  ConnectionPolicy conn_policy = current_entry->conn; // response送信完了
+  response.pop_response();
+  current_entry = 0;
+
+  if (conn_policy == CP_WILL_CLOSE) {
+    return IO_SHOULD_CLOSE;
+  } else if (conn_policy == CP_MUST_CLOSE) {
+    client_state = CLIENT_HALF_CLOSED;
+    return IO_SHOULD_SHUTDOWN;
+  }
+  return has_response() ? IO_CONTINUE : IO_WRITE_COMPLETE;
 }
 
-bool Client::on_parse() {
+IOStatus Client::on_half_close() {
+  LOG_DEBUG_FUNC();
+  while (parser.parse()) {
+    if (request.get_connection_policy() == CP_WILL_CLOSE) {
+      log(LOG_DEBUG, "Graceful shutdown confirmed from client.");
+      return IO_SHOULD_CLOSE;
+    }
+    parser.clear();
+  }
+  return IO_CONTINUE;
+}
+
+IOStatus Client::on_parse() {
   LOG_DEBUG_FUNC();
   while (parser.parse()) {
     // trueの場合、requestの解析が完了しレスポンスを生成できる状態
@@ -62,11 +85,13 @@ bool Client::on_parse() {
     request.handle_http_request();
     parser.clear(); // 状態をclearして, 再びheaderのparseを待機
   }
-  return has_response();
+  return has_response() ? IO_READY_TO_WRITE : IO_CONTINUE;
 }
 
 bool Client::has_response() const {
-  return (!response_buffer.empty() || response.has_next_response());
+  // 送信中の entry または これから送信を開始できる is_ready な entry がある
+  return ((current_entry && current_entry->is_ready) ||
+          response.has_next_response());
 }
 
 Client &Client::operator=(const Client &other) {

--- a/srcs/event/KqueueMultiplexer.cpp
+++ b/srcs/event/KqueueMultiplexer.cpp
@@ -34,6 +34,7 @@ void KqueueMultiplexer::run() {
       if (errno == EINTR) {
         continue;
       }
+      log(LOG_ERROR, "kqueue() is not working: "); // errno出す
       throw std::runtime_error("kqueue() failed");
     }
 
@@ -71,12 +72,7 @@ void KqueueMultiplexer::unmonitor_write(int fd) {
 
 void KqueueMultiplexer::unmonitor(int fd) {
   LOG_DEBUG_FUNC_FD(fd);
-  struct kevent ev_read;
-  struct kevent ev_write;
-  EV_SET(&ev_read, fd, EVFILT_READ, EV_DELETE, 0, 0, 0);
-  EV_SET(&ev_write, fd, EVFILT_WRITE, EV_DELETE, 0, 0, 0);
-  change_list.push_back(ev_read);
-  change_list.push_back(ev_write);
+  // do nothing here for kqueue
 }
 
 bool KqueueMultiplexer::is_readable(struct kevent &ev) const {

--- a/srcs/event/Multiplexer.cpp
+++ b/srcs/event/Multiplexer.cpp
@@ -191,14 +191,13 @@ void Multiplexer::read_from_client(int client_fd) {
   Client *client = get_client_from_map(client_fd);
 
   switch (client->on_read()) {
-  case IO_SUCCESS:
-    monitor_write(client_fd);
-    break;
+
   case IO_CONTINUE:
     break;
-  case IO_CLOSED:
-    remove_client(client_fd);
+  case IO_DONE:
+    monitor_write(client_fd);
     break;
+  case IO_CLOSED:
   case IO_ERROR:
     remove_client(client_fd);
     break;
@@ -213,12 +212,9 @@ void Multiplexer::write_to_client(int client_fd) {
   Client *client = get_client_from_map(client_fd);
 
   switch (client->on_write()) {
-  case IO_SUCCESS:
-    unmonitor_write(client_fd);
-    break;
   case IO_CONTINUE:
     break;
-  case IO_CLOSED:
+  case IO_DONE:
     unmonitor_write(client_fd);
     break;
   case IO_ERROR:


### PR DESCRIPTION
##  Connection: close / keep-alive 対応 + graceful shutdown

###  対応済み

- **Connection: close を受信した場合、以降のリクエストを処理せず接続を終了**
`Connection: close` の指定がある場合、response 送信後に `client_fd` を close

- **graceful close: HALF_CLOSE → CLOSE の実装**
server 起因の切断（framing errorやtimeout）では、`shutdown(SHUT_WR)` → `Connection: close` の受信を待ってから、 `close(fd)` を実行する（優雅な切断 by RFC）

- **`Connection:` ヘッダを response に含めるよう対応**
HttpResponse 内で ConnectionPolicy に応じた値（keep-alive / close）を付与

---

###  未対応（今後の課題）

- **framing error 検出時に ConnectionPolicy を `MUST_CLOSE` にする処理**
- **非 framing error 時も、body を最後まで読み込んでから error response を返す制御**
framing error / non framing error 共に、ヘッダーに関わるので、ヘッダーのデータ構造を修正してから対応する

- **timeout の実装**
  - body incomplete な状態での無通信
  - half-close からの応答が来ないままの放置 など