### PR TITLE
server周りのリファクタとserver_name対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,24 @@ CXX      := c++
 CXXFLAGS := -Wall -Wextra -Werror -std=c++98 -MMD -MP
 SRCDIR   := srcs
 OBJDIR   := objs
-SRCS     := $(SRCDIR)/main.cpp $(SRCDIR)/server/Server.cpp $(SRCDIR)/Utils.cpp \
+SRCS     := $(SRCDIR)/main.cpp \
+            $(SRCDIR)/server/Server.cpp \
+            $(SRCDIR)/server/ServerRegistry.cpp \
+            $(SRCDIR)/server/VirtualHostRouter.cpp \
+            $(SRCDIR)/server/ServerBuilder.cpp \
+            $(SRCDIR)/server/SocketBuilder.cpp \
+            $(SRCDIR)/client/Client.cpp \
+            $(SRCDIR)/client/ClientRegistry.cpp \
+            $(SRCDIR)/client/ConnectionManager.cpp \
+            $(SRCDIR)/http/HttpRequest.cpp \
+            $(SRCDIR)/http/HttpResponse.cpp \
+            $(SRCDIR)/http/HttpRequestParser.cpp \
             $(SRCDIR)/config/ConfigParse.cpp \
-			$(SRCDIR)/event/Multiplexer.cpp \
-			$(SRCDIR)/event/SelectMultiplexer.cpp \
-			$(SRCDIR)/event/PollMultiplexer.cpp \
-			$(SRCDIR)/http/HttpRequest.cpp \
-			$(SRCDIR)/http/HttpResponse.cpp \
-			$(SRCDIR)/client/Client.cpp \
-			$(SRCDIR)/http/HttpRequestParser.cpp
+            $(SRCDIR)/event/Multiplexer.cpp \
+            $(SRCDIR)/event/SelectMultiplexer.cpp \
+            $(SRCDIR)/event/PollMultiplexer.cpp \
+            $(SRCDIR)/utils/Logger.cpp \
+            $(SRCDIR)/utils/Utils.cpp
 
 UNAME_S := $(shell uname -s)
 
@@ -64,6 +73,11 @@ redir: $(NAME)
 	./$(NAME) config/valid/redir_practice.conf
 	@echo "== Tests Completed =="
 
+multiserver: $(NAME)
+	@echo "== Running Tests  =="
+	./$(NAME) config/valid/multiple_servers3.conf
+	@echo "== Tests Completed =="
+
 func: fclean
 	$(MAKE) LOG_LEVEL=0
 	$(MAKE) run
@@ -96,5 +110,11 @@ filedelete:
 dirdelete:
 	curl -X DELETE http://localhost:8080/menu/ -v
 
+routetest:
+	curl -H "Host: aaa.com" http://localhost:8080/
+	curl -H "Host: bbb.com" http://localhost:8080/
+	curl -H "Host: unknown.com" http://localhost:8080/
+	curl -H "Host: aaa.com:8080" http://localhost:8080/
+	curl -H "Host: bbb.com:8080" http://localhost:8080/
 
 .PHONY: all clean fclean re run redir debug quiet test redirtest debug

--- a/config/valid/multiple_servers3.conf
+++ b/config/valid/multiple_servers3.conf
@@ -1,0 +1,11 @@
+server {
+    listen 8080;
+    server_name aaa.com;
+    root ./public_aaa;
+}
+
+server {
+    listen 8080;
+    server_name bbb.com;
+    root ./public_bbb;
+}

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -1,0 +1,46 @@
+## 構成:
+Server             <- 1つの server{} block を表す設定
+VirtualHostRouter  <- host:port に属する Server 群のrouter
+ServerRegistry     <- 検索用の registry
+ServerBuilder      <- config から Server 群を生成し、VirtualHostRouter に登録
+SocketBuilder　　　 <- server fd作成
+
+## 実行順序:
+0. confファイルの server_config, location_configs を解析する
+1. ServerRegistry のインスタンスを用意する
+2. ServerBuilderが、config情報に基づいてServerインスタンスを作成し、ServerRegistryに登録する
+3. その際、同じポート番号の Server 達をまとめて VirtualHostRouter にまとめる
+4. ServerRegistryが、initialize()をしてSocketBuilderを呼び出し、各サーバーのsocketを有効なものとする
+   └ 各 Server が listenポート・server_name・location などの情報を持ってる
+5. Requestのヘッダ情報を元に、VirtualHostRouterが適切なServerインスタンスを選ぶ
+
+## 各クラスの説明
+### Server クラス
+- `server_config` と `location_configs` を保持
+- Hostヘッダーの値と `server_name` の照合を担当
+- `matches_host()` 関数で、受信したリクエストと一致するかを判定
+
+### VirtualHostRouter クラス
+- ひとつのポートに対して複数の `Server` インスタンスをまとめる
+- Hostヘッダーに応じたルーティング (`route_by_host()`) を担当
+- マッチするサーバーがなかった場合は `default_server` にフォールバックする
+
+### ServerRegistry クラス
+- `ListenEntry`（fd, ip, port, VirtualHostRouter）を管理する
+- fd → VirtualHostRouter のマッピングを保持し、リクエスト受付時に使用される
+- Serverの登録 (`add()`)、ソケットの初期化 (`initialize()`)、fdの削除 (`remove()`) を担当
+
+### ClientRegistry クラス
+- fd → Client のマッピングを管理
+- クライアントの接続を追加 (`add()`)、削除 (`remove()`) できる
+- fdのclose操作も責任を持って行う（ClientRegistryがfdの所有権を持つ）
+
+### ServerBuilder クラス
+- 設定（ConfigMapとLocationMap）から Serverインスタンスを生成する
+- ServerインスタンスをServerRegistryに登録する
+
+### SocketBuilder クラス
+- ソケット作成・設定 (`socket/bind/listen`) を担当する
+
+
+

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -5,7 +5,7 @@
 #include "HttpResponse.hpp"
 #include <string>
 
-class Server;
+class VirtualHostRouter;
 
 enum IOStatus {
   IO_CONTINUE,        // 現状維持（read/write継続）
@@ -22,21 +22,22 @@ enum ClientState {
 
 class Client {
 public:
-  Client(int clientfd, int serverfd);
+  Client(int clientfd, const VirtualHostRouter *router);
   ~Client();
+
+  int get_fd() const;
 
   IOStatus on_read();
   IOStatus on_write();
 
 private:
-  int fd;                   // client fd
-  int server_fd;            // このclientが接続しているserver fd
+  int fd; // client fd
+  ClientState client_state;
+
   HttpResponse response;    // responseの生成とqueue管理
   HttpRequest request;      // header情報, body, contentLengthなどの管理
   HttpRequestParser parser; // header, bodyの解析管理
 
-  ClientState client_state;
-  // std::string response_buffer; // 現在送信中のbuffer
   ResponseEntry *current_entry; // 現在送信中のresponse entry;
   size_t response_sent;         // send済みのbytes数
 

--- a/includes/ClientRegistry.hpp
+++ b/includes/ClientRegistry.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <map>
 
 class Client;

--- a/includes/ClientRegistry.hpp
+++ b/includes/ClientRegistry.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <map>
+
+class Client;
+
+class ClientRegistry {
+public:
+  ClientRegistry();
+  ~ClientRegistry();
+
+  void add(int fd, Client *client);
+  void remove(int fd);
+  Client *get(int fd) const;
+  bool has(int fd) const;
+  size_t size() const;
+
+private:
+  std::map<int, Client *> clients;
+
+  typedef std::map<int, Client *>::iterator ClientIt;
+  typedef std::map<int, Client *>::const_iterator ConstClientIt;
+
+  ClientRegistry(const ClientRegistry &other);
+  ClientRegistry &operator=(const ClientRegistry &other);
+};

--- a/includes/ConnectionManager.hpp
+++ b/includes/ConnectionManager.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+class Client;
+
+class ConnectionManager {
+public:
+  static int accept_new_connection(int server_fd);
+};

--- a/includes/HttpRequest.hpp
+++ b/includes/HttpRequest.hpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:44:38 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/04/21 22:47:32 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/04/29 20:10:03 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,7 @@
 #include <vector>
 
 class HttpResponse;
+class VirtualHostRouter;
 
 enum ResourceType { File, Directory, NotFound };
 enum RedirStatus { REDIR_NONE, REDIR_SUCCESS, REDIR_FAILED };
@@ -40,10 +41,8 @@ public:
   std::string method;
   std::string path;
   std::string version;
-  // std::string body;
-  std::vector<char> body_data;
-  // std::map<std::string, std::string> headers;
   HeaderMap headers;
+  std::vector<char> body_data;
 
   bool is_autoindex_enabled;
   std::string index_file_name;
@@ -55,7 +54,7 @@ public:
   LocationMap location_configs;
   ConfigMap best_match_config;
 
-  HttpRequest(int server_fd, HttpResponse &httpResponse);
+  HttpRequest(const VirtualHostRouter *router, HttpResponse &httpResponse);
   ~HttpRequest();
   void handle_http_request();
 
@@ -68,7 +67,8 @@ public:
   size_t get_max_body_size() const;
 
   const std::string &get_header_value(const std::string &key) const;
-  const std::vector<std::string> &get_header_values(const std::string &key) const;
+  const std::vector<std::string> &
+  get_header_values(const std::string &key) const;
   void add_header(const std::string &key, const std::string &value);
   bool is_in_headers(const std::string &key) const;
 
@@ -81,6 +81,7 @@ public:
 
 private:
   HttpResponse &response;
+  const VirtualHostRouter *virtual_host_router;
   ConnectionPolicy connection_policy;
   int status_code;
   std::string _root;
@@ -88,8 +89,10 @@ private:
 
   static const size_t k_default_max_body;
 
+  void select_server_by_host();
   void conf_init();
-  std::map<int, std::string> extract_error_page_map(const std::vector<std::string>& tokens);
+  std::map<int, std::string>
+  extract_error_page_map(const std::vector<std::string> &tokens);
   void init_cgi_extensions();
   void init_file_index();
   void merge_config(ConfigMap &base, const ConfigMap &override);

--- a/includes/Logger.hpp
+++ b/includes/Logger.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+enum LogLevel { LOG_FUNC, LOG_INFO, LOG_DEBUG, LOG_WARNING, LOG_ERROR };
+
+extern LogLevel current_log_level;
+extern std::ofstream debug_log;
+
+void log(LogLevel level, const std::string &message);
+void logfd(LogLevel level, const std::string &prefix, int fd);
+
+#define LOG_DEBUG_FUNC() log(LOG_FUNC, std::string(__func__) + "() called")
+#define LOG_DEBUG_FUNC_FD(fd)                                                  \
+  logfd(LOG_FUNC, std::string(__func__) + "() called on fd: ", fd)
+
+#define RED "\033[1;31m"
+#define GREEN "\033[1;32m"
+#define YELLOW "\033[1;33m"
+#define CYAN "\033[1;36m"
+#define RESET "\033[0m"

--- a/includes/Multiplexer.hpp
+++ b/includes/Multiplexer.hpp
@@ -6,6 +6,8 @@
 
 class Server;
 class Client;
+class ServerRegistry;
+class ClientRegistry;
 
 /**
  * Server の I/O 多重化を管理する基底クラス
@@ -17,28 +19,6 @@ public:
   static void delete_instance();
 
   virtual void run() = 0;
-  void add_to_server_map(int fd, Server *server);
-  Server *get_server_from_map(int fd) const;
-
-protected:
-  // Singleton pattern
-  static Multiplexer *instance;
-
-  // server_mapの管理
-  void remove_from_server_map(int fd);
-  bool is_in_server_map(int fd) const;
-  size_t get_num_servers() const;
-
-  // client_mapの管理
-  void add_to_client_map(int fd, Client *client);
-  void remove_from_client_map(int fd);
-  bool is_in_client_map(int fd) const;
-  Client *get_client_from_map(int fd) const;
-  size_t get_num_clients() const;
-
-  // I/O多重化処理の管理
-  void initialize_fds();
-  void process_event(int fd, bool readable, bool writable);
 
   // 監視fd管理用の純粋仮想関数
   virtual void monitor_read(int fd) = 0;
@@ -46,23 +26,24 @@ protected:
   virtual void unmonitor_write(int fd) = 0;
   virtual void unmonitor(int fd) = 0;
 
-  // 解放処理（fd close & clientのみインスタンス削除）
-  void free_all_fds();
+  void set_server_registry(ServerRegistry *registry);
+  void set_client_registry(ClientRegistry *registry);
+
+protected:
+  // Singleton pattern
+  static Multiplexer *instance;
+
+  // I/O多重化処理の管理
+  void process_event(int fd, bool readable, bool writable);
 
   Multiplexer();
   Multiplexer(const Multiplexer &other);
   virtual ~Multiplexer();
 
 private:
-  // mapのiterator型定義
-  typedef std::map<int, Server *>::iterator ServerIt;
-  typedef std::map<int, Client *>::iterator ClientIt;
-  typedef std::map<int, Server *>::const_iterator ConstServerIt;
-  typedef std::map<int, Client *>::const_iterator ConstClientIt;
-
-  // client, server の fd管理
-  std::map<int, Server *> server_map; // serverfd -> Server*
-  std::map<int, Client *> client_map; // clientfd -> Client*
+  // Registry
+  ServerRegistry *server_registry;
+  ClientRegistry *client_registry;
 
   // I/O多重化処理の補助関数
   void accept_client(int server_fd);
@@ -74,3 +55,23 @@ private:
   // 代入禁止
   Multiplexer &operator=(const Multiplexer &other);
 };
+
+/*
+try {
+    add_to_client_map(client_fd, new Client(client_fd, server_fd));
+  } catch (const std::exception &e) {
+    logfd(LOG_ERROR, e.what(), client_fd);
+    close(client_fd);
+    return;
+  }
+  Multiplexer::get_instance().monitor_read(client_fd);
+  // monitor_read(client_fd);
+  logfd(LOG_DEBUG, "New connection on client fd: ", client_fd);
+
+void ConnectionManager::remove_connection(Client *client, int client_fd) {
+  LOG_DEBUG_FUNC_FD(client_fd);
+  unmonitor(client_fd);
+  remove_from_client_map(client_fd); // close, delete もこの中
+}
+
+*/

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -1,44 +1,28 @@
 #pragma once
 
 #include "types.hpp"
-#include <cstring>
-#include <fstream>
-#include <iostream>
 #include <map>
-#include <netinet/in.h>
-#include <sstream>
-#include <stdexcept>
 #include <string>
-#include <unistd.h>
-#include <utility>
 #include <vector>
-
-// #include "HttpRequest.hpp"
 
 class Server {
 public:
   Server(const ConfigMap &config, const LocationMap &locations);
+  Server(const Server &src);
   ~Server();
-
-  void createSockets();
 
   const ConfigMap &get_config() const;
   const LocationMap &get_locations() const;
+
+  bool matches_host(const std::string &host) const;
 
 private:
   ConfigMap server_config;
   LocationMap location_configs;
 
-  std::vector<int> listenPorts_;
   std::string public_root;
   std::string error_404;
-  // HttpRequestはServerではなくClientに持たせたいためコメントアウト
-  // HttpRequest httpRequest;
-
-  int createListenSocket(int port);
-  void listenSocket(int sockfd, std::string portStr);
 
   Server();
-  Server(const Server &src);
   Server &operator=(const Server &src);
 };

--- a/includes/ServerBuilder.hpp
+++ b/includes/ServerBuilder.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "types.hpp"
+
+class ServerRegistry;
+
+class ServerBuilder {
+public:
+  static void build(const ServerAndLocationConfigs &config_pairs,
+                    ServerRegistry &registry);
+};

--- a/includes/ServerRegistry.hpp
+++ b/includes/ServerRegistry.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <map>
+#include <vector>
+
+class Server;
+class VirtualHostRouter;
+
+struct ListenEntry {
+  int fd;
+  std::string ip;
+  std::string port;
+  VirtualHostRouter *virtual_host_router;
+};
+
+class ServerRegistry {
+public:
+  ServerRegistry();
+  ~ServerRegistry();
+
+  void add(const Server &s);
+  void remove(int fd);
+  bool has(int fd) const;
+  size_t size() const;
+
+  void initialize();
+
+  const VirtualHostRouter *get_router(int fd) const;
+
+private:
+  std::vector<ListenEntry> entries;
+
+  typedef std::vector<ListenEntry>::iterator ListenEntryIt;
+  typedef std::vector<ListenEntry>::const_iterator ConstListenEntryIt;
+
+  void create_new_listen_target(const std::string &ip, const std::string &port,
+                                const Server &s);
+
+  ServerRegistry(const ServerRegistry &other);
+  ServerRegistry &operator=(const ServerRegistry &other);
+};
+

--- a/includes/ServerRegistry.hpp
+++ b/includes/ServerRegistry.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstddef>
 #include <map>
+#include <string>
 #include <vector>
 
 class Server;
@@ -39,4 +41,3 @@ private:
   ServerRegistry(const ServerRegistry &other);
   ServerRegistry &operator=(const ServerRegistry &other);
 };
-

--- a/includes/SocketBuilder.hpp
+++ b/includes/SocketBuilder.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <string>
+
+class SocketBuilder {
+public:
+  static int create_socket(const std::string &ip, const std::string &port);
+};

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -20,23 +21,9 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
-// #include <thread>
-#include <cstdlib>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <vector>
-
-#define RESET "\033[0m"
-#define RED "\033[31m"
-#define YELLOW "\033[33m"
-#define GREEN "\033[32m"
-#define CYAN "\033[36m"
-#define MAGENTA "\033[35m"
-#define GRAY "\033[90m"
-
-#define LOG_DEBUG_FUNC() log(LOG_FUNC, std::string(__func__) + "() called")
-#define LOG_DEBUG_FUNC_FD(fd)                                                  \
-  logfd(LOG_FUNC, std::string(__func__) + "() called on fd: ", fd)
 
 // kosekiさんから引き継いだ時点でのServer classのheader（一旦コメントアウト）
 // class Server {
@@ -79,18 +66,9 @@ int print_error_message(const std::string &message);
 // utils
 bool file_exists(const std::string &path);
 bool ends_with(const std::string &str, const std::string &suffix);
-bool has_index_file(const std::string &dir_path,std::string index_file_name);
+bool has_index_file(const std::string &dir_path, std::string index_file_name);
 bool is_directory(const std::string &path);
 std::string make_unique_filename();
-
-// log
-enum LogLevel { LOG_FUNC, LOG_INFO, LOG_DEBUG, LOG_WARNING, LOG_ERROR };
-// global 変数宣言
-extern LogLevel current_log_level;
-extern std::ofstream debug_log;
-
-void log(LogLevel level, const std::string &message);
-void logfd(LogLevel level, const std::string &prefix, int fd);
 
 // trim string
 std::string trim_left(const std::string &s);
@@ -105,4 +83,4 @@ size_t parse_hex(const std::string &s);
 std::vector<std::string> split_csv(const std::string &value);
 std::string to_lower(const std::string &s);
 
-bool is_all_digits(const std::string& str);
+bool is_all_digits(const std::string &str);

--- a/includes/VirtualHostRouter.hpp
+++ b/includes/VirtualHostRouter.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+class Server;
+
+class VirtualHostRouter {
+public:
+  VirtualHostRouter();
+  ~VirtualHostRouter();
+
+  void add(Server *s);
+  Server *route_by_host(const std::string &host) const;
+
+private:
+  std::vector<Server *> servers;
+
+  VirtualHostRouter(const VirtualHostRouter &other);
+  VirtualHostRouter &operator=(const VirtualHostRouter &other);
+};

--- a/public_aaa/index.html
+++ b/public_aaa/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Webserv Test</title>
+</head>
+<body>
+  <h1>Welcome to Public AAA!</h1>
+</body>
+</html>

--- a/public_bbb/index.html
+++ b/public_bbb/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Webserv Test</title>
+</head>
+<body>
+  <h1>Welcome to Public BBB!</h1>
+</body>
+</html>

--- a/srcs/client/Client.cpp
+++ b/srcs/client/Client.cpp
@@ -2,18 +2,19 @@
 #include "Client.hpp"
 #include "HttpRequest.hpp"
 #include "HttpResponse.hpp"
-#include "Utils.hpp"
+#include "Logger.hpp"
+#include <cstddef>
 #include <sstream>
 #include <stdexcept>
 
-// TODO: timeout処理が必要 あとで
-
-Client::Client(int clientfd, int serverfd)
-    : fd(clientfd), server_fd(serverfd), response(),
-      request(serverfd, response), parser(request), client_state(CLIENT_ALIVE),
+Client::Client(int clientfd, const VirtualHostRouter *router)
+    : fd(clientfd), client_state(CLIENT_ALIVE), response(),
+      request(router, response), parser(request), current_entry(NULL),
       response_sent(0) {}
 
 Client::~Client() {}
+
+int Client::get_fd() const { return fd; }
 
 IOStatus Client::on_read() {
   LOG_DEBUG_FUNC();

--- a/srcs/client/ClientRegistry.cpp
+++ b/srcs/client/ClientRegistry.cpp
@@ -1,7 +1,6 @@
 #include "ClientRegistry.hpp"
 #include "Client.hpp"
 #include "Logger.hpp"
-#include <cstddef>
 
 ClientRegistry::ClientRegistry() {}
 

--- a/srcs/client/ClientRegistry.cpp
+++ b/srcs/client/ClientRegistry.cpp
@@ -1,0 +1,58 @@
+#include "ClientRegistry.hpp"
+#include "Client.hpp"
+#include "Logger.hpp"
+#include <cstddef>
+
+ClientRegistry::ClientRegistry() {}
+
+ClientRegistry::~ClientRegistry() {
+  for (ClientIt it = clients.begin(); it != clients.end(); ++it) {
+    if (it->first != -1 && close(it->first) == -1) {
+      logfd(LOG_ERROR, "Failed to close client fd: ", it->first);
+    }
+    delete it->second;
+  }
+  clients.clear();
+}
+
+void ClientRegistry::add(int fd, Client *client) {
+  if (has(fd)) {
+    logfd(LOG_ERROR, "Duplicate client fd: ", fd);
+    return;
+  }
+  clients[fd] = client;
+}
+
+// Note: ClientRegistryがfdの所有権を持つため、ここでclose(fd)
+void ClientRegistry::remove(int fd) {
+  ClientIt it = clients.find(fd);
+  if (it == clients.end()) {
+    logfd(LOG_ERROR, "Client not in registry fd: ", fd);
+    return;
+  }
+  if (close(it->first) == -1) {
+    logfd(LOG_ERROR, "Failed to close client fd: ", fd);
+  }
+  delete it->second;
+  clients.erase(fd);
+}
+
+Client *ClientRegistry::get(int fd) const {
+  ConstClientIt it = clients.find(fd);
+  if (it == clients.end()) {
+    logfd(LOG_ERROR, "Failed to find client fd: ", fd);
+    return NULL;
+  }
+  return it->second;
+}
+
+bool ClientRegistry::has(int fd) const {
+  return clients.find(fd) != clients.end();
+}
+
+size_t ClientRegistry::size() const { return clients.size(); }
+
+ClientRegistry &ClientRegistry::operator=(const ClientRegistry &other) {
+  (void)other;
+  return *this;
+}

--- a/srcs/client/ConnectionManager.cpp
+++ b/srcs/client/ConnectionManager.cpp
@@ -1,0 +1,27 @@
+#include "ConnectionManager.hpp"
+#include "Client.hpp"
+#include "Logger.hpp"
+#include <fcntl.h>
+
+int ConnectionManager::accept_new_connection(int server_fd) {
+  LOG_DEBUG_FUNC_FD(server_fd);
+  struct sockaddr_storage client_addr;
+  socklen_t addrlen = sizeof(client_addr);
+  int new_fd = accept(server_fd, (struct sockaddr *)&client_addr, &addrlen);
+  if (new_fd == -1) {
+    logfd(LOG_ERROR, "Failed to accept new connection on socket: ", server_fd);
+    return -1;
+  }
+  if (fcntl(new_fd, F_SETFL, fcntl(new_fd, F_GETFL) | O_NONBLOCK) == -1) {
+    logfd(LOG_ERROR, "Failed to set O_NONBLOCK on socket: ", new_fd);
+    close(new_fd);
+    return -1;
+  }
+  int opt = 1;
+  if (setsockopt(new_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1) {
+    logfd(LOG_ERROR, "Failed to set SO_REUSEADDR on socket: ", new_fd);
+    close(new_fd);
+    return -1;
+  }
+  return new_fd;
+}

--- a/srcs/event/EpollMultiplexer.cpp
+++ b/srcs/event/EpollMultiplexer.cpp
@@ -1,5 +1,5 @@
 #include "EpollMultiplexer.hpp"
-#include "Utils.hpp"
+#include "Logger.hpp"
 #include <cstdlib>
 #include <iostream>
 
@@ -21,7 +21,6 @@ void EpollMultiplexer::run() {
     throw std::runtime_error("epoll_create");
   }
   std::vector<struct epoll_event> evlist;
-  initialize_fds();
 
   while (true) {
     if (size > max_epoll_events) {

--- a/srcs/event/KqueueMultiplexer.cpp
+++ b/srcs/event/KqueueMultiplexer.cpp
@@ -1,5 +1,5 @@
 #include "KqueueMultiplexer.hpp"
-#include "Utils.hpp"
+#include "Logger.hpp"
 #include <cstdlib>
 #include <iostream>
 #include <sys/event.h>
@@ -20,7 +20,6 @@ void KqueueMultiplexer::run() {
   static const int max_kqueue_events = 16384;
   int kq = kqueue();
   int size = 16;
-  initialize_fds();
 
   while (true) {
     if (size >= max_kqueue_events) {

--- a/srcs/event/Multiplexer.cpp
+++ b/srcs/event/Multiplexer.cpp
@@ -1,12 +1,13 @@
 #include "Multiplexer.hpp"
 #include "Client.hpp"
+#include "ClientRegistry.hpp"
+#include "ConnectionManager.hpp"
 #include "EpollMultiplexer.hpp"
 #include "KqueueMultiplexer.hpp"
+#include "Logger.hpp"
 #include "PollMultiplexer.hpp"
 #include "SelectMultiplexer.hpp"
-#include "Server.hpp"
-#include "Utils.hpp"
-#include <fcntl.h>
+#include "ServerRegistry.hpp"
 #include <iostream>
 #include <sstream>
 #include <string.h>
@@ -30,219 +31,116 @@ Multiplexer &Multiplexer::get_instance() {
 }
 
 void Multiplexer::delete_instance() {
-  delete instance;
+  if (instance) {
+    delete instance;
+  }
   instance = 0;
 }
 
-void Multiplexer::add_to_server_map(int fd, Server *server) {
-  if (is_in_server_map(fd)) {
-    std::ostringstream oss;
-    oss << "Duplicate server fd: " << fd;
-    throw std::runtime_error(oss.str());
-  }
-  server_map[fd] = server;
+void Multiplexer::set_server_registry(ServerRegistry *registry) {
+  server_registry = registry;
 }
 
-void Multiplexer::remove_from_server_map(int fd) {
-  ServerIt it = server_map.find(fd);
-  if (it != server_map.end()) {
-    close(it->first);
-    delete it->second;
-    server_map.erase(it);
-  }
-}
-
-bool Multiplexer::is_in_server_map(int fd) const {
-  return server_map.find(fd) != server_map.end();
-}
-
-Server *Multiplexer::get_server_from_map(int fd) const {
-  ConstServerIt it = server_map.find(fd);
-  if (it == server_map.end()) {
-    std::ostringstream oss;
-    oss << "Server not found for fd: " << fd;
-    throw std::runtime_error(oss.str());
-  }
-  return it->second;
-}
-
-size_t Multiplexer::get_num_servers() const { return server_map.size(); }
-
-void Multiplexer::add_to_client_map(int fd, Client *client) {
-  if (is_in_client_map(fd)) {
-    std::ostringstream oss;
-    oss << "Duplicate client fd: " << fd;
-    throw std::runtime_error(oss.str());
-  }
-  client_map[fd] = client;
-}
-
-void Multiplexer::remove_from_client_map(int fd) {
-  ClientIt it = client_map.find(fd);
-  if (it != client_map.end()) {
-    if (close(it->first) == -1) {
-      logfd(LOG_ERROR, "Failed to close client fd: ", fd);
-    } else {
-      logfd(LOG_DEBUG, "Closed client fd: ", fd);
-    }
-    delete it->second;
-    client_map.erase(fd);
-  }
-}
-
-bool Multiplexer::is_in_client_map(int fd) const {
-  return client_map.find(fd) != client_map.end();
-}
-
-Client *Multiplexer::get_client_from_map(int fd) const {
-  ConstClientIt it = client_map.find(fd);
-  if (it == client_map.end()) {
-    std::ostringstream oss;
-    oss << "Client not found for fd: " << fd;
-    throw std::runtime_error(oss.str());
-  }
-  return it->second;
-}
-
-size_t Multiplexer::get_num_clients() const { return client_map.size(); }
-
-void Multiplexer::initialize_fds() {
-  LOG_DEBUG_FUNC();
-  if (server_map.empty()) {
-    throw std::runtime_error("Error: No servers available.");
-  }
-  for (ServerIt it = server_map.begin(); it != server_map.end(); ++it) {
-    monitor_read(it->first);
-  }
+void Multiplexer::set_client_registry(ClientRegistry *registry) {
+  client_registry = registry;
 }
 
 void Multiplexer::process_event(int fd, bool readable, bool writable) {
   if (!readable && !writable) {
     return;
   }
-  if (is_in_server_map(fd)) {
+  if (server_registry->has(fd)) {
     if (readable) {
       accept_client(fd);
     }
     return;
   }
-  if (is_in_client_map(fd) && readable) {
-    read_from_client(fd);
+  if (client_registry->has(fd)) {
+    if (readable) {
+      read_from_client(fd);
+    }
+    if (writable) {
+      write_to_client(fd);
+    }
   }
-  if (is_in_client_map(fd) && writable) {
-    write_to_client(fd);
-  }
-}
-
-void Multiplexer::free_all_fds() {
-  for (ServerIt it = server_map.begin(); it != server_map.end(); ++it) {
-    close(it->first);
-    // delete it->second;
-    // 複数のfd（port）が同じserverに結びつくので、ここでserverインスタンスを削除できない
-  }
-  server_map.clear();
-  for (ClientIt it = client_map.begin(); it != client_map.end(); ++it) {
-    close(it->first);
-    delete it->second;
-  }
-  client_map.clear();
 }
 
 Multiplexer::Multiplexer() {}
 
 Multiplexer::Multiplexer(const Multiplexer &other) { (void)other; }
 
-Multiplexer::~Multiplexer() { free_all_fds(); }
+Multiplexer::~Multiplexer() {}
 
-void Multiplexer::accept_client(int server_fd) {
-  LOG_DEBUG_FUNC_FD(server_fd);
-  struct sockaddr_storage client_addr;
-  socklen_t addrlen = sizeof(client_addr);
-  int client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &addrlen);
-  if (client_fd == -1) {
-    log(LOG_ERROR, "accept failed");
-    return;
-  }
-  if (fcntl(client_fd, F_SETFL, fcntl(client_fd, F_GETFL) | O_NONBLOCK) == -1) {
-    logfd(LOG_ERROR, "Failed to set O_NONBLOCK: ", client_fd);
-    close(client_fd);
-    return;
-  }
-  int optval = 1;
-  if (setsockopt(client_fd, SOL_SOCKET, SO_REUSEADDR, &optval,
-                 sizeof(optval)) == -1) {
-    logfd(LOG_ERROR, "Failed to set SO_REUSEADDR on client fd: ", client_fd);
-    close(client_fd);
+void Multiplexer::accept_client(int serverfd) {
+  LOG_DEBUG_FUNC_FD(serverfd);
+  int clientfd = ConnectionManager::accept_new_connection(serverfd);
+  if (clientfd == -1) {
+    log(LOG_DEBUG, "Failed to process new connection");
     return;
   }
 
-  try {
-    add_to_client_map(client_fd, new Client(client_fd, server_fd));
-  } catch (const std::exception &e) {
-    logfd(LOG_ERROR, e.what(), client_fd);
-    close(client_fd);
-    return;
-  }
-  monitor_read(client_fd);
-  logfd(LOG_DEBUG, "New connection on client fd: ", client_fd);
+  Client *client = new Client(clientfd, server_registry->get_router(serverfd));
+  client_registry->add(clientfd, client);
+  monitor_read(clientfd);
+  logfd(LOG_DEBUG, "New connection on client socket: ", clientfd);
 }
 
-void Multiplexer::read_from_client(int client_fd) {
-  LOG_DEBUG_FUNC_FD(client_fd);
-  Client *client = get_client_from_map(client_fd);
+void Multiplexer::read_from_client(int clientfd) {
+  LOG_DEBUG_FUNC_FD(clientfd);
+  Client *client = client_registry->get(clientfd);
 
   switch (client->on_read()) {
 
   case IO_CONTINUE:
     break;
   case IO_READY_TO_WRITE:
-    monitor_write(client_fd);
+    monitor_write(clientfd);
     break;
   case IO_SHOULD_CLOSE:
-    remove_client(client_fd);
+    remove_client(clientfd);
     break;
   default:
-    logfd(LOG_ERROR, "Unhandled I/O Status: ", client_fd);
-    remove_client(client_fd);
+    logfd(LOG_ERROR, "Unhandled I/O Status on client socket: ", clientfd);
+    remove_client(clientfd);
   }
 }
 
-void Multiplexer::write_to_client(int client_fd) {
-  LOG_DEBUG_FUNC_FD(client_fd);
-  Client *client = get_client_from_map(client_fd);
+void Multiplexer::write_to_client(int clientfd) {
+  LOG_DEBUG_FUNC_FD(clientfd);
+  Client *client = client_registry->get(clientfd);
 
   switch (client->on_write()) {
   case IO_CONTINUE:
     break;
   case IO_WRITE_COMPLETE:
-    unmonitor_write(client_fd);
+    unmonitor_write(clientfd);
     break;
   case IO_SHOULD_SHUTDOWN:
-    shutdown_write(client_fd);
+    shutdown_write(clientfd);
     break;
   case IO_SHOULD_CLOSE:
-    remove_client(client_fd);
+    remove_client(clientfd);
     break;
   default:
-    logfd(LOG_ERROR, "Unhandled I/O Status: ", client_fd);
-    remove_client(client_fd);
+    logfd(LOG_ERROR, "Unhandled I/O Status on client socket: ", clientfd);
+    remove_client(clientfd);
   }
 }
 
-void Multiplexer::shutdown_write(int client_fd) {
-  LOG_DEBUG_FUNC_FD(client_fd);
-  if (shutdown(client_fd, SHUT_WR) == -1) {
-    logfd(LOG_ERROR, "shutdown() failed for fd: ", client_fd);
-    remove_client(client_fd);
+void Multiplexer::shutdown_write(int clientfd) {
+  LOG_DEBUG_FUNC_FD(clientfd);
+  if (shutdown(clientfd, SHUT_WR) == -1) {
+    logfd(LOG_ERROR, "shutdown() failed for fd: ", clientfd);
+    remove_client(clientfd);
     return;
   }
-  unmonitor_write(client_fd);
+  unmonitor_write(clientfd);
 }
 
-void Multiplexer::remove_client(int client_fd) {
-  LOG_DEBUG_FUNC_FD(client_fd);
-  unmonitor(client_fd);
-  remove_from_client_map(client_fd); // close, delete もこの中
+void Multiplexer::remove_client(int clientfd) {
+  LOG_DEBUG_FUNC_FD(clientfd);
+  unmonitor(clientfd);
+  client_registry->remove(clientfd);
 }
 
 Multiplexer &Multiplexer::operator=(const Multiplexer &other) {

--- a/srcs/event/PollMultiplexer.cpp
+++ b/srcs/event/PollMultiplexer.cpp
@@ -1,6 +1,6 @@
 #include "PollMultiplexer.hpp"
+#include "Logger.hpp"
 #include "Server.hpp"
-#include "Utils.hpp"
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
@@ -19,8 +19,7 @@ Multiplexer &PollMultiplexer::get_instance() {
 void PollMultiplexer::run() {
   LOG_DEBUG_FUNC();
   static const int max_poll_events = 65536;
-  pfds.reserve(get_num_servers());
-  initialize_fds();
+
   if (pfds.empty()) {
     throw std::runtime_error("pollfd empty");
   }

--- a/srcs/event/SelectMultiplexer.cpp
+++ b/srcs/event/SelectMultiplexer.cpp
@@ -1,5 +1,5 @@
 #include "SelectMultiplexer.hpp"
-#include "Utils.hpp"
+#include "Logger.hpp"
 #include <cstdlib>
 #include <iostream>
 #include <string.h>
@@ -18,7 +18,6 @@ Multiplexer &SelectMultiplexer::get_instance() {
 
 void SelectMultiplexer::run() {
   LOG_DEBUG_FUNC();
-  initialize_fds();
 
   while (true) {
     if (max_fd >= FD_SETSIZE) {

--- a/srcs/http/HttpResponse.cpp
+++ b/srcs/http/HttpResponse.cpp
@@ -6,11 +6,12 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:37:08 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/04/21 22:43:14 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/04/30 00:36:53 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "HttpResponse.hpp"
+#include "Logger.hpp"
 #include "Utils.hpp"
 
 HttpResponse::HttpResponse() {}
@@ -61,7 +62,9 @@ void HttpResponse::generate_response(int status_code,
 }
 
 void HttpResponse::generate_custom_error_page(int status_code,
-                                              const std::string &error_page, std::string _root, ConnectionPolicy conn) {
+                                              const std::string &error_page,
+                                              std::string _root,
+                                              ConnectionPolicy conn) {
   LOG_DEBUG_FUNC();
   try {
     std::string file_content = read_file(_root + error_page);

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -1,32 +1,23 @@
 #include "Server.hpp"
 #include "ConfigParse.hpp"
-#include "Multiplexer.hpp"
-#include <cstring>
-#include <fcntl.h>
-#include <netdb.h>
-#include <sstream>
-#include <sys/socket.h>
-#include <sys/types.h>
+#include <algorithm>
 
+// TODO: 確認
 Server::Server(const ConfigMap &config, const LocationMap &locations)
     : server_config(config), location_configs(locations) {
-  // listen
-  ConstConfigIt listen_it = config.find("listen");
-  if (listen_it == config.end() || listen_it->second.empty())
-    print_error_message("Missing required key: listen");
-
-  for (size_t i = 0; i < listen_it->second.size(); i++) {
-    int port;
-    std::stringstream ss(listen_it->second[i]);
-    if (!(ss >> port))
-      print_error_message("Invalid port number: " + listen_it->second[i]);
-    listenPorts_.push_back(port);
-  }
 
   ConstConfigIt error_it = config.find("error_page 404");
   error_404 = (error_it != config.end() && !error_it->second.empty())
                   ? error_it->second[0]
                   : "404.html";
+}
+
+// TODO: 確認
+Server::Server(const Server &src) {
+  server_config = src.server_config;
+  location_configs = src.location_configs;
+  public_root = src.public_root;
+  error_404 = src.error_404;
 }
 
 Server::~Server() {}
@@ -35,129 +26,17 @@ const ConfigMap &Server::get_config() const { return server_config; }
 
 const LocationMap &Server::get_locations() const { return location_configs; }
 
-void Server::createSockets() {
-  std::vector<int> tempFds;
-  try {
-    for (size_t i = 0; i < listenPorts_.size(); i++) {
-      int serverFd = createListenSocket(listenPorts_[i]);
-      tempFds.push_back(serverFd);
-      Multiplexer::get_instance().add_to_server_map(serverFd, this);
-    }
-    log(LOG_INFO, "Socket created and options set successfully");
-  } catch (...) {
-    for (size_t i = 0; i < tempFds.size(); i++) {
-      close(tempFds[i]);
-    }
-    throw;
+// TODO: wildcard server_name への対応（ ex. *.example.com ）
+bool Server::matches_host(const std::string &host_name) const {
+  ConstConfigIt it = server_config.find("server_name");
+  if (it == server_config.end()) {
+    return false;
   }
+  const std::vector<std::string> &names = it->second;
+  return std::find(names.begin(), names.end(), host_name) != names.end();
 }
-
-int Server::createListenSocket(int port) {
-  int server_fd = -1, status, opt = 1;
-  struct addrinfo hints, *ai, *p;
-  std::stringstream ss;
-  ss << port;
-  std::string port_str = ss.str();
-
-  std::memset(&hints, 0, sizeof(hints));
-  hints.ai_family = AF_UNSPEC;     // IPv4 or IPv6 両方対応
-  hints.ai_socktype = SOCK_STREAM; // stream sockets
-  hints.ai_flags = AI_PASSIVE;     // serverなので fill in my IP as host
-
-  if ((status = getaddrinfo(NULL, port_str.c_str(), &hints, &ai)) != 0) {
-    throw std::runtime_error("getaddrinfo error for port " + port_str + ": " +
-                             std::string(gai_strerror(status)));
-  }
-  // 複数の結果がgetaddrinfoに入っている。順に試す
-  for (p = ai; p; p = p->ai_next) {
-    server_fd = -1;
-    if ((server_fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) ==
-        -1) {
-      continue;
-    }
-    if (fcntl(server_fd, F_SETFL, fcntl(server_fd, F_GETFL) | O_NONBLOCK) ==
-        -1) {
-      logfd(LOG_ERROR, "Failed to set O_NONBLOCK on server fd: ", server_fd);
-      close(server_fd);
-      continue;
-    }
-    if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) ==
-        -1) {
-      close(server_fd);
-      continue;
-    }
-    if (bind(server_fd, p->ai_addr, p->ai_addrlen) == -1) {
-      close(server_fd);
-      continue;
-    }
-    // socket(), setsockopt(), bind() 全部成功したらloopを抜ける
-    logfd(LOG_INFO, "Socket bound to port ", port);
-    break;
-  }
-  freeaddrinfo(ai);
-  if (!p) {
-    throw std::runtime_error("Faild to prepare socket for port: " + port_str);
-  }
-  listenSocket(server_fd, port_str);
-  return server_fd;
-}
-
-void Server::listenSocket(int server_fd, std::string portStr) {
-  if (listen(server_fd, SOMAXCONN) < 0) {
-    close(server_fd);
-    throw std::runtime_error("Failed to listen on port: " + portStr);
-  }
-  logfd(LOG_INFO, "Server is listening on port " + portStr + " fd:", server_fd);
-}
-
-Server::Server() {}
-
-Server::Server(const Server &src) { (void)src; }
 
 Server &Server::operator=(const Server &src) {
   (void)src;
   return *this;
 }
-
-// server
-// ではなく、clientからの呼び出しでhandleHttpできるようにするためコメントアウト
-// void Server::handleHttp(int clientFd, const char *buffer, int nbytes) {
-//   httpRequest.handleHttpRequest(clientFd, buffer, nbytes);
-// }
-
-// Server::Server(const Server &src)
-//     : config(src.config), listen_ports(src.listen_ports),
-//     public_root(src.public_root),
-//       error_404(src.error_404), server_fds()
-// {
-//     try {
-//         create_sockets();  // コピー時に新しくソケットを作る
-//     } catch (const std::exception& e) {
-//         throw std::runtime_error("Error copying server: " +
-//         std::string(e.what()));
-//     }
-// }
-
-// Server& Server::operator=(const Server &src)
-// {
-//     if (this != &src)
-//     {
-//         config = src.config;
-//         listen_ports = src.listen_ports;
-//         public_root = src.public_root;
-//         error_404 = src.error_404;
-
-//         for (size_t i = 0; i < server_fds.size(); i++) {
-//             close(server_fds[i]);
-//         }
-//         server_fds.clear();
-
-//         try {
-//             create_sockets();
-//         } catch (const std::exception& e) {
-//             throw std::runtime_error("Error copying server: " +
-//             std::string(e.what()));
-//         }
-//     }
-//     return *this;
-// }

--- a/srcs/server/ServerBuilder.cpp
+++ b/srcs/server/ServerBuilder.cpp
@@ -1,6 +1,7 @@
 #include "ServerBuilder.hpp"
 #include "Server.hpp"
 #include "ServerRegistry.hpp"
+#include <stdexcept>
 
 void ServerBuilder::build(const ServerAndLocationConfigs &config_pairs,
                           ServerRegistry &registry) {

--- a/srcs/server/ServerBuilder.cpp
+++ b/srcs/server/ServerBuilder.cpp
@@ -1,0 +1,14 @@
+#include "ServerBuilder.hpp"
+#include "Server.hpp"
+#include "ServerRegistry.hpp"
+
+void ServerBuilder::build(const ServerAndLocationConfigs &config_pairs,
+                          ServerRegistry &registry) {
+  if (config_pairs.empty()) {
+    throw std::runtime_error("No valid server configurations found.");
+  }
+  for (size_t i = 0; i < config_pairs.size(); i++) {
+    Server server(config_pairs[i].first, config_pairs[i].second);
+    registry.add(server);
+  }
+}

--- a/srcs/server/ServerRegistry.cpp
+++ b/srcs/server/ServerRegistry.cpp
@@ -1,10 +1,9 @@
 #include "ServerRegistry.hpp"
+#include "Logger.hpp"
 #include "Multiplexer.hpp"
 #include "Server.hpp"
 #include "SocketBuilder.hpp"
-#include "Logger.hpp"
 #include "VirtualHostRouter.hpp"
-#include <cstddef>
 #include <iostream>
 #include <unistd.h>
 

--- a/srcs/server/ServerRegistry.cpp
+++ b/srcs/server/ServerRegistry.cpp
@@ -1,0 +1,108 @@
+#include "ServerRegistry.hpp"
+#include "Multiplexer.hpp"
+#include "Server.hpp"
+#include "SocketBuilder.hpp"
+#include "Logger.hpp"
+#include "VirtualHostRouter.hpp"
+#include <cstddef>
+#include <iostream>
+#include <unistd.h>
+
+ServerRegistry::ServerRegistry() {}
+
+ServerRegistry::~ServerRegistry() {
+  for (size_t i = 0; i < entries.size(); ++i) {
+    if (entries[i].fd != -1 && close(entries[i].fd) == -1) {
+      logfd(LOG_ERROR, "Failed to close server fd: ", entries[i].fd);
+    }
+    delete entries[i].virtual_host_router;
+  }
+}
+
+// XXX: listen が必ず最低でも1つあることは、config parse時にチェックする
+// XXX: 重複についての検証はどこでするか確認する
+void ServerRegistry::add(const Server &s) {
+  std::vector<std::string> ip_ports = s.get_config().find("listen")->second;
+  std::string ip, port;
+
+  for (size_t i = 0; i < ip_ports.size(); ++i) {
+
+    size_t colon_pos = ip_ports[i].find(':');
+    if (colon_pos == std::string::npos) {
+      ip = "0.0.0.0";
+      port = ip_ports[i];
+    } else {
+      ip = ip_ports[i].substr(0, colon_pos);
+      port = ip_ports[i].substr(colon_pos + 1);
+    }
+
+    size_t j;
+    for (j = 0; j < entries.size(); ++j) {
+      if (ip == entries[j].ip && port == entries[j].port) {
+        entries[j].virtual_host_router->add(new Server(s));
+        break;
+      }
+    }
+    if (j == entries.size()) {
+      create_new_listen_target(ip, port, s);
+    }
+  }
+}
+
+void ServerRegistry::remove(int fd) {
+  for (ListenEntryIt it = entries.begin(); it != entries.end(); ++it) {
+    if (it->fd == fd) {
+      if (close(it->fd) == -1) {
+        logfd(LOG_ERROR, "Failed to close server fd: ", it->fd);
+      }
+      delete it->virtual_host_router;
+      entries.erase(it);
+      return;
+    }
+  }
+}
+
+bool ServerRegistry::has(int fd) const {
+  for (size_t i = 0; i < entries.size(); ++i) {
+    if (entries[i].fd == fd) {
+      return true;
+    }
+  }
+  return false;
+}
+
+size_t ServerRegistry::size() const { return entries.size(); }
+
+void ServerRegistry::initialize() {
+  for (size_t i = 0; i < entries.size(); ++i) {
+    int fd = SocketBuilder::create_socket(entries[i].ip, entries[i].port);
+    entries[i].fd = fd;
+    Multiplexer::get_instance().monitor_read(fd);
+  }
+}
+
+const VirtualHostRouter *ServerRegistry::get_router(int fd) const {
+  for (ConstListenEntryIt it = entries.begin(); it != entries.end(); ++it) {
+    if (it->fd == fd) {
+      return it->virtual_host_router;
+    }
+  }
+  return NULL;
+}
+
+void ServerRegistry::create_new_listen_target(const std::string &ip,
+                                              const std::string &port,
+                                              const Server &s) {
+  struct ListenEntry entry;
+  entry.fd = -1;
+  entry.ip = ip;
+  entry.port = port;
+  entry.virtual_host_router = new VirtualHostRouter;
+  entry.virtual_host_router->add(new Server(s));
+  entries.push_back(entry);
+}
+
+ServerRegistry &ServerRegistry::operator=(const ServerRegistry &other) {
+  (void)other;
+  return *this;
+}

--- a/srcs/server/SocketBuilder.cpp
+++ b/srcs/server/SocketBuilder.cpp
@@ -1,0 +1,46 @@
+#include "SocketBuilder.hpp"
+#include "Logger.hpp"
+#include "unistd.h"
+#include <cstring>
+#include <fcntl.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+int SocketBuilder::create_socket(const std::string &ip,
+                                 const std::string &port) {
+  int sockfd = -1, status, opt = 1;
+  struct addrinfo hints, *ai, *p;
+
+  std::memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;     // IPv4 or IPv6 両方対応
+  hints.ai_socktype = SOCK_STREAM; // stream sockets
+  hints.ai_flags = AI_PASSIVE;     // fill in my IP as host
+
+  if ((status = getaddrinfo(ip.c_str(), port.c_str(), &hints, &ai)) != 0) {
+    throw std::runtime_error("getaddrinfo error for " + ip + ":" + port +
+                             ", status: " + std::string(gai_strerror(status)));
+  }
+
+  // 複数の結果がgetaddrinfoに入っている。順に試す
+  for (p = ai; p; p = p->ai_next) {
+    sockfd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+    if (sockfd == -1) {
+      continue;
+    }
+    if (fcntl(sockfd, F_SETFL, fcntl(sockfd, F_GETFL) | O_NONBLOCK) == -1 ||
+        setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1 ||
+        bind(sockfd, p->ai_addr, p->ai_addrlen) == -1 ||
+        listen(sockfd, SOMAXCONN) == -1) {
+      close(sockfd);
+      continue;
+    }
+    break; // 成功
+  }
+  freeaddrinfo(ai);
+  if (!p) {
+    throw std::runtime_error("Failed to prepare socket for " + ip + ":" + port);
+  }
+  logfd(LOG_INFO, "Now listening on " + ip + ":" + port + " fd: ", sockfd);
+  return sockfd;
+}

--- a/srcs/server/VirtualHostRouter.cpp
+++ b/srcs/server/VirtualHostRouter.cpp
@@ -1,0 +1,35 @@
+#include "VirtualHostRouter.hpp"
+#include "Server.hpp"
+#include <cstddef>
+
+VirtualHostRouter::VirtualHostRouter() : servers() {}
+
+VirtualHostRouter::~VirtualHostRouter() {
+  for (size_t i = 0; i < servers.size(); ++i) {
+    delete servers[i];
+  }
+}
+
+void VirtualHostRouter::add(Server *s) { servers.push_back(s); }
+
+Server *VirtualHostRouter::route_by_host(const std::string &host) const {
+  size_t colon_pos = host.find(':');
+  std::string host_name;
+  if (colon_pos != std::string::npos) {
+    host_name = host.substr(0, colon_pos);
+  } else {
+    host_name = host;
+  }
+  for (size_t i = 0; i < servers.size(); ++i) {
+    if (servers[i]->matches_host(host_name)) {
+      return servers[i];
+    }
+  }
+  return servers.empty() ? NULL : servers[0];
+}
+
+VirtualHostRouter &
+VirtualHostRouter::operator=(const VirtualHostRouter &other) {
+  (void)other;
+  return *this;
+}

--- a/srcs/utils/Logger.cpp
+++ b/srcs/utils/Logger.cpp
@@ -1,0 +1,55 @@
+#include "Logger.hpp"
+#include <cerrno>
+#include <cstring>
+#include <sstream>
+
+#ifndef LOG_LEVEL
+#define LOG_LEVEL LOG_INFO
+#endif
+
+LogLevel current_log_level = static_cast<LogLevel>(LOG_LEVEL);
+
+std::ofstream debug_log("debug.log");
+
+void log(LogLevel level, const std::string &message) {
+  if (level >= current_log_level) {
+    switch (level) {
+    case LOG_FUNC:
+      std::cout << CYAN << "[FUNC] " << RESET << message << std::endl;
+      debug_log << "[FUNC] " << message << std::endl;
+      break;
+    case LOG_INFO:
+      std::cout << GREEN << "[INFO] " << RESET << message << std::endl;
+      debug_log << "[INFO] " << message << std::endl;
+      break;
+    case LOG_DEBUG:
+      debug_log << "[DEBUG] " << message << std::endl;
+      break;
+    case LOG_WARNING:
+      std::cerr << YELLOW << "[WARNING] " << RESET << message << std::endl;
+      debug_log << "[WARNING] " << message << std::endl;
+      break;
+    case LOG_ERROR:
+      std::cerr << RED << "[ERROR] " << RESET << message;
+      debug_log << "[ERROR] " << message;
+      if (errno != 0) {
+        int err = errno;
+        errno = 0;
+        std::cerr << " (errno: " << err << ", reason: " << strerror(err) << ")";
+        debug_log << " (errno: " << err << ", reason: " << strerror(err) << ")";
+      }
+      std::cerr << std::endl;
+      debug_log << std::endl;
+      break;
+    default:
+      std::cerr << "[UNKNOWN] " << message << std::endl;
+      debug_log << "[UNKNOWN] " << message << std::endl;
+    }
+  }
+}
+
+void logfd(LogLevel level, const std::string &message, int fd) {
+  std::ostringstream oss;
+  oss << message << fd;
+  log(level, oss.str());
+}

--- a/srcs/utils/Utils.cpp
+++ b/srcs/utils/Utils.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/18 15:47:21 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/04/21 22:42:57 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/04/30 00:26:35 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,10 +59,10 @@ std::string make_unique_filename() {
   return ss.str();
 }
 
-bool is_all_digits(const std::string& str) {
+bool is_all_digits(const std::string &str) {
   for (size_t i = 0; i < str.size(); ++i) {
-      if (!std::isdigit(str[i]))
-          return false;
+    if (!std::isdigit(str[i]))
+      return false;
   }
   return true;
 }
@@ -95,50 +95,6 @@ bool is_all_digits(const std::string& str) {
 //     // デフォルトのMIMEタイプ
 //     return "application/octet-stream";
 // }
-
-#ifndef LOG_LEVEL
-#define LOG_LEVEL LOG_INFO
-#endif
-
-LogLevel current_log_level = static_cast<LogLevel>(LOG_LEVEL);
-
-std::ofstream debug_log("debug.log");
-
-void log(LogLevel level, const std::string &message) {
-  if (level >= current_log_level) {
-    switch (level) {
-    case LOG_FUNC:
-      std::cout << CYAN << "[FUNC] " << RESET << message << std::endl;
-      break;
-    case LOG_INFO:
-      std::cout << GREEN << "[INFO] " << RESET << message << std::endl;
-      break;
-    case LOG_DEBUG:
-      debug_log << "[DEBUG] " << message << std::endl;
-      break;
-    case LOG_WARNING:
-      std::cerr << YELLOW << "[WARNING] " << RESET << message << std::endl;
-      break;
-    case LOG_ERROR:
-      std::cerr << RED << "[ERROR] " << RESET << message;
-      if (errno != 0) {
-        int err = errno;
-        errno = 0;
-        std::cerr << " (errno: " << err << ", reason: " << strerror(err) << ")";
-      }
-      std::cerr << std::endl;
-      break;
-    default:
-      std::cerr << "[UNKNOWN] " << message << std::endl;
-    }
-  }
-}
-
-void logfd(LogLevel level, const std::string &message, int fd) {
-  std::ostringstream oss;
-  oss << message << fd;
-  log(level, oss.str());
-}
 
 std::string trim_left(const std::string &s) {
   size_t start = s.find_first_not_of(" \t\r\n");


### PR DESCRIPTION
## 説明
Server周りを中心にリファクタを行い、MultiplexerはI/Oイベント管理に専念するようになった  
ServerRegistry/ClientRegistryがfdとServer/Clientインスタンスを管理する
複数server_nameに対応するため、VirtualHostRouterによるrouting

## 実行順序
0. confファイルから server_config, location_configs を解析
1. ServerRegistry を初期化
2. ServerBuilder が Serverインスタンスを作成して ServerRegistry に登録
3. 同一ポートの Server 群を VirtualHostRouter にまとめる
4. ServerRegistry の initialize() で各サーバーソケットを生成し listen 状態にする
5. リクエストの Hostヘッダに応じて VirtualHostRouter が適切なServerを選択

## 各クラスの説明
### Server
- `server_config`, `location_configs` を保持
- Hostヘッダと server_name のマッチング

### VirtualHostRouter
- 1つのポートに属する複数Serverを管理
- Hostヘッダに応じたServerルーティング

### ServerRegistry
- ListenEntry（fd, ip, port, VirtualHostRouter）を管理
- server_fd -> VirtualHostRouter のマッピング

### ClientRegistry
- client_fd -> Client のマッピング

### ServerBuilder
- config情報から Serverインスタンスを生成し、ServerRegistry に登録

### SocketBuilder
- ソケット作成・設定 (socket / bind / listen)

## 試し方
```
make multiserver
make routetest
```

## 関連
- close #62 