### PR TITLE
feat: clientのtime-out処理の実装

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -16,8 +16,12 @@ enum IOStatus {
 };
 
 enum ClientState {
-  CLIENT_ALIVE,      // 通常
-  CLIENT_HALF_CLOSED // SHUT_WR 済み; EOF or `Connection: close` 待ち
+  CLIENT_ALIVE,       // 通常
+  CLIENT_CGI_PENDING, // CGIをpollに噛ませるときに使う予定
+  CLIENT_TIMED_OUT,   // Time-out; `time out`レスポンスを送りたい
+  CLIENT_HALF_CLOSED, // SHUT_WR 済み; EOF or `Connection: close` 待ち
+  // TIMED_OUTはレスポンスを送り次第, HALF_CLOSEDになる
+  // CLOSEDなclientはdeleteするのでCLIENT_CLOSEDは省略
 };
 
 class Client {
@@ -29,21 +33,29 @@ public:
 
   IOStatus on_read();
   IOStatus on_write();
+  IOStatus on_timeout();
+
+  bool is_timeout(time_t now) const;
+  bool is_unresponsive(time_t now) const;
 
 private:
-  int fd; // client fd
-  ClientState client_state;
+  int fd_; // client fd
+  ClientState client_state_;
+  time_t timeout_sec_;
+  time_t last_activity_;
 
-  HttpResponse response;    // responseの生成とqueue管理
-  HttpRequest request;      // header情報, body, contentLengthなどの管理
-  HttpRequestParser parser; // header, bodyの解析管理
+  HttpResponse response_;    // responseの生成とqueue管理
+  HttpRequest request_;      // header情報, body, contentLengthなどの管理
+  HttpRequestParser parser_; // header, bodyの解析管理
 
-  ResponseEntry *current_entry; // 現在送信中のresponse entry;
-  size_t response_sent;         // send済みのbytes数
+  ResponseEntry *current_entry_; // 現在送信中のresponse entry;
+  size_t response_sent_;         // send済みのbytes数
 
   IOStatus on_parse();
   IOStatus on_half_close();
   bool has_response() const;
+
+  void update_activity();
 
   Client(const Client &other);
   Client &operator=(const Client &other);

--- a/includes/ClientRegistry.hpp
+++ b/includes/ClientRegistry.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <map>
+#include <vector>
 
 class Client;
 
@@ -16,8 +17,11 @@ public:
   bool has(int fd) const;
   size_t size() const;
 
+  std::vector<int> mark_timed_out_clients();
+  std::vector<int> detect_unresponsive_clients() const;
+
 private:
-  std::map<int, Client *> clients;
+  std::map<int, Client *> clients_;
 
   typedef std::map<int, Client *>::iterator ClientIt;
   typedef std::map<int, Client *>::const_iterator ConstClientIt;

--- a/includes/HttpResponse.hpp
+++ b/includes/HttpResponse.hpp
@@ -3,18 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   HttpResponse.hpp                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: koseki.yusuke <koseki.yusuke@student.42    +#+  +:+       +#+        */
+/*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:44:51 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/04/21 13:23:17 by koseki.yusu      ###   ########.fr       */
+/*   Updated: 2025/05/15 14:36:00 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #pragma once
 
 #include "ResponseTypes.hpp"
+#include <deque>
 #include <iostream>
-#include <queue>
 #include <sstream>
 #include <string>
 #include <sys/socket.h>
@@ -30,8 +30,8 @@ public:
   HttpResponse();
   ~HttpResponse();
 
-  ResponseEntry *get_next_response();
-  void pop_response();
+  ResponseEntry *get_front_response();
+  void pop_front_response();
   bool has_next_response() const;
 
   void generate_custom_error_page(int status_code,
@@ -47,12 +47,15 @@ public:
                          ConnectionPolicy connection_policy);
   void generate_redirect(int status_code, const std::string &new_location,
                          ConnectionPolicy conn);
+  void generate_timeout_response();
 
 private:
-  std::queue<ResponseEntry> response_queue;
+  std::deque<ResponseEntry> response_deque_;
 
-  void push_response(ConnectionPolicy connection_policy,
-                     const std::string &response);
+  void push_front_response(ConnectionPolicy connection_policy,
+                           const std::string &response);
+  void push_back_response(ConnectionPolicy connection_policy,
+                          const std::string &response);
   const char *get_status_message(int status_code);
   const char *to_connection_value(ConnectionPolicy conn) const;
 

--- a/includes/Multiplexer.hpp
+++ b/includes/Multiplexer.hpp
@@ -31,10 +31,13 @@ public:
 
 protected:
   // Singleton pattern
-  static Multiplexer *instance;
+  static Multiplexer *instance_;
+
+  static const int k_timeout_ms_;
 
   // I/O多重化処理の管理
   void process_event(int fd, bool readable, bool writable);
+  void handle_timeouts();
 
   Multiplexer();
   Multiplexer(const Multiplexer &other);
@@ -42,8 +45,8 @@ protected:
 
 private:
   // Registry
-  ServerRegistry *server_registry;
-  ClientRegistry *client_registry;
+  ServerRegistry *server_registry_;
+  ClientRegistry *client_registry_;
 
   // I/O多重化処理の補助関数
   void accept_client(int server_fd);
@@ -55,23 +58,3 @@ private:
   // 代入禁止
   Multiplexer &operator=(const Multiplexer &other);
 };
-
-/*
-try {
-    add_to_client_map(client_fd, new Client(client_fd, server_fd));
-  } catch (const std::exception &e) {
-    logfd(LOG_ERROR, e.what(), client_fd);
-    close(client_fd);
-    return;
-  }
-  Multiplexer::get_instance().monitor_read(client_fd);
-  // monitor_read(client_fd);
-  logfd(LOG_DEBUG, "New connection on client fd: ", client_fd);
-
-void ConnectionManager::remove_connection(Client *client, int client_fd) {
-  LOG_DEBUG_FUNC_FD(client_fd);
-  unmonitor(client_fd);
-  remove_from_client_map(client_fd); // close, delete もこの中
-}
-
-*/

--- a/includes/types.hpp
+++ b/includes/types.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 // 汎用
+typedef std::vector<int> IntVector;
 typedef std::vector<std::string> StrVector;
 typedef std::map<std::string, std::string> StrToStrMap;
 
@@ -16,6 +17,9 @@ typedef std::map<std::string, std::map<std::string, std::vector<std::string> > >
 typedef std::vector<std::pair<ConfigMap, LocationMap> > ServerAndLocationConfigs;
 
 // iterator
+typedef IntVector::iterator IntVecIt;
+typedef IntVector::const_iterator ConstIntVecIt;
+
 typedef ConfigMap::iterator ConfigIt;
 typedef ConfigMap::const_iterator ConstConfigIt;
 typedef LocationMap::iterator LocationIt;
@@ -25,7 +29,6 @@ typedef StrToStrMap::iterator StrToStrMapIt;
 typedef StrToStrMap::const_iterator ConstStrToStrMapIt;
 
 // HeaderMap
-
 struct CaseInsensitiveLess {
   bool operator()(const std::string &a, const std::string &b) const {
     std::string lower_a = a;

--- a/srcs/client/Client.cpp
+++ b/srcs/client/Client.cpp
@@ -7,26 +7,34 @@
 #include <sstream>
 #include <stdexcept>
 
+// TODO: timeoutのconfigに基づく設定はあとで考慮する
 Client::Client(int clientfd, const VirtualHostRouter *router)
-    : fd(clientfd), client_state(CLIENT_ALIVE), response(),
-      request(router, response), parser(request), current_entry(NULL),
-      response_sent(0) {}
+    : fd_(clientfd), client_state_(CLIENT_ALIVE), timeout_sec_(15),
+      last_activity_(time(NULL)), response_(), request_(router, response_),
+      parser_(request_), current_entry_(NULL), response_sent_(0) {}
 
 Client::~Client() {}
 
-int Client::get_fd() const { return fd; }
+int Client::get_fd() const { return fd_; }
 
 IOStatus Client::on_read() {
   LOG_DEBUG_FUNC();
   const int buf_size = 1024;
   char buffer[buf_size];
-  ssize_t bytes_read = recv(fd, buffer, sizeof(buffer), 0);
+  ssize_t bytes_read = recv(fd_, buffer, sizeof(buffer), 0);
   if (bytes_read == -1 || bytes_read == 0) {
     return IO_SHOULD_CLOSE;
   }
-  parser.append_data(buffer, bytes_read);
 
-  if (client_state == CLIENT_HALF_CLOSED) {
+  std::string debug(buffer, bytes_read);
+
+  update_activity();
+  parser_.append_data(buffer, bytes_read);
+
+  if (client_state_ == CLIENT_TIMED_OUT) {
+    return IO_CONTINUE; // Time-outのレスポンス送信中。clientからの入力は無視する
+  }
+  if (client_state_ == CLIENT_HALF_CLOSED) {
     return on_half_close();
   }
   return on_parse();
@@ -34,68 +42,94 @@ IOStatus Client::on_read() {
 
 IOStatus Client::on_write() {
   LOG_DEBUG_FUNC();
-  if (client_state == CLIENT_HALF_CLOSED || !has_response()) {
+  if (client_state_ == CLIENT_HALF_CLOSED || !has_response()) {
     return IO_WRITE_COMPLETE;
   }
-  if (!current_entry) {
-    current_entry = response.get_next_response();
-    response_sent = 0;
+  if (!current_entry_) {
+    current_entry_ = response_.get_front_response();
+    response_sent_ = 0;
   }
 
-  ssize_t bytes_sent = send(fd, current_entry->buffer.c_str() + response_sent,
-                            current_entry->buffer.size() - response_sent, 0);
+  std::string &send_buffer = current_entry_->buffer;
+  ssize_t bytes_sent = send(fd_, send_buffer.c_str() + response_sent_,
+                            send_buffer.size() - response_sent_, 0);
   if (bytes_sent == -1 || bytes_sent == 0) {
     return IO_SHOULD_CLOSE;
   }
+  update_activity();
 
-  response_sent += bytes_sent;
-  if (response_sent < current_entry->buffer.size()) {
+  response_sent_ += bytes_sent;
+  if (response_sent_ < current_entry_->buffer.size()) {
     return IO_CONTINUE; // 今回のsendで、response全体を送信できなかった
   }
 
-  ConnectionPolicy conn_policy = current_entry->conn; // response送信完了
-  response.pop_response();
-  current_entry = 0;
+  ConnectionPolicy conn_policy = current_entry_->conn; // response送信完了
+  response_.pop_front_response();
+  current_entry_ = 0;
 
   if (conn_policy == CP_WILL_CLOSE) {
     return IO_SHOULD_CLOSE;
   } else if (conn_policy == CP_MUST_CLOSE) {
-    client_state = CLIENT_HALF_CLOSED;
+    client_state_ = CLIENT_HALF_CLOSED;
     return IO_SHOULD_SHUTDOWN;
   }
   return has_response() ? IO_CONTINUE : IO_WRITE_COMPLETE;
 }
 
+// stateの更新と、timeout responseの準備
+IOStatus Client::on_timeout() {
+  if (client_state_ != CLIENT_ALIVE) {
+    return IO_CONTINUE;
+  }
+  client_state_ = CLIENT_TIMED_OUT;
+  current_entry_ = 0;
+  response_.generate_timeout_response();
+  update_activity();
+  return IO_READY_TO_WRITE; // monitor_write()を促す
+}
+
 IOStatus Client::on_half_close() {
   LOG_DEBUG_FUNC();
-  while (parser.parse()) {
-    if (request.get_connection_policy() == CP_WILL_CLOSE) {
+  while (parser_.parse()) {
+    if (request_.get_connection_policy() == CP_WILL_CLOSE) {
       log(LOG_DEBUG, "Graceful shutdown confirmed from client.");
       return IO_SHOULD_CLOSE;
     }
-    parser.clear();
+    parser_.clear();
   }
   return IO_CONTINUE;
 }
 
 IOStatus Client::on_parse() {
   LOG_DEBUG_FUNC();
-  while (parser.parse()) {
+  while (parser_.parse()) {
     // trueの場合、requestの解析が完了しレスポンスを生成できる状態
     // request内でresponseクラスにresponseをpushしている
-    request.handle_http_request();
-    if (request.get_connection_policy() != CP_KEEP_ALIVE) {
+    request_.handle_http_request();
+    if (request_.get_connection_policy() != CP_KEEP_ALIVE) {
       break;
     }
-    parser.clear(); // 状態をclearして, 再びheaderのparseを待機
+    parser_.clear(); // 状態をclearして, 再びheaderのparseを待機
   }
   return has_response() ? IO_READY_TO_WRITE : IO_CONTINUE;
 }
 
 bool Client::has_response() const {
   // 送信中の entry または これから送信を開始できる is_ready な entry がある
-  return ((current_entry && current_entry->is_ready) ||
-          response.has_next_response());
+  return ((current_entry_ && current_entry_->is_ready) ||
+          response_.has_next_response());
+}
+
+void Client::update_activity() { last_activity_ = time(NULL); }
+
+bool Client::is_timeout(time_t now) const {
+  return (client_state_ == CLIENT_ALIVE && now - last_activity_ > timeout_sec_);
+}
+
+bool Client::is_unresponsive(time_t now) const {
+  return ((client_state_ == CLIENT_TIMED_OUT ||
+           client_state_ == CLIENT_HALF_CLOSED) &&
+          now - last_activity_ > timeout_sec_);
 }
 
 Client &Client::operator=(const Client &other) {

--- a/srcs/client/ClientRegistry.cpp
+++ b/srcs/client/ClientRegistry.cpp
@@ -5,13 +5,13 @@
 ClientRegistry::ClientRegistry() {}
 
 ClientRegistry::~ClientRegistry() {
-  for (ClientIt it = clients.begin(); it != clients.end(); ++it) {
+  for (ClientIt it = clients_.begin(); it != clients_.end(); ++it) {
     if (it->first != -1 && close(it->first) == -1) {
       logfd(LOG_ERROR, "Failed to close client fd: ", it->first);
     }
     delete it->second;
   }
-  clients.clear();
+  clients_.clear();
 }
 
 void ClientRegistry::add(int fd, Client *client) {
@@ -19,13 +19,13 @@ void ClientRegistry::add(int fd, Client *client) {
     logfd(LOG_ERROR, "Duplicate client fd: ", fd);
     return;
   }
-  clients[fd] = client;
+  clients_[fd] = client;
 }
 
 // Note: ClientRegistryがfdの所有権を持つため、ここでclose(fd)
 void ClientRegistry::remove(int fd) {
-  ClientIt it = clients.find(fd);
-  if (it == clients.end()) {
+  ClientIt it = clients_.find(fd);
+  if (it == clients_.end()) {
     logfd(LOG_ERROR, "Client not in registry fd: ", fd);
     return;
   }
@@ -33,12 +33,12 @@ void ClientRegistry::remove(int fd) {
     logfd(LOG_ERROR, "Failed to close client fd: ", fd);
   }
   delete it->second;
-  clients.erase(fd);
+  clients_.erase(fd);
 }
 
 Client *ClientRegistry::get(int fd) const {
-  ConstClientIt it = clients.find(fd);
-  if (it == clients.end()) {
+  ConstClientIt it = clients_.find(fd);
+  if (it == clients_.end()) {
     logfd(LOG_ERROR, "Failed to find client fd: ", fd);
     return NULL;
   }
@@ -46,10 +46,39 @@ Client *ClientRegistry::get(int fd) const {
 }
 
 bool ClientRegistry::has(int fd) const {
-  return clients.find(fd) != clients.end();
+  return clients_.find(fd) != clients_.end();
 }
 
-size_t ClientRegistry::size() const { return clients.size(); }
+size_t ClientRegistry::size() const { return clients_.size(); }
+
+std::vector<int> ClientRegistry::mark_timed_out_clients() {
+  time_t now = time(NULL);
+  std::vector<int> timed_out_clients;
+  timed_out_clients.reserve(clients_.size());
+
+  for (ClientIt it = clients_.begin(); it != clients_.end(); ++it) {
+    if (it->second->is_timeout(now)) {
+      it->second->on_timeout(); // stateの更新と、timeout responseの準備
+      timed_out_clients.push_back(it->first);
+    }
+  }
+  // multiplexerにmonitor_write()を頼みたいfdsを渡す
+  return timed_out_clients;
+}
+
+std::vector<int> ClientRegistry::detect_unresponsive_clients() const {
+  time_t now = time(NULL);
+  std::vector<int> unresponsive_clients;
+  unresponsive_clients.reserve(clients_.size());
+
+  for (ConstClientIt it = clients_.begin(); it != clients_.end(); ++it) {
+    if (it->second->is_unresponsive(now)) {
+      unresponsive_clients.push_back(it->first);
+    }
+  }
+  // multiplexerにforce closeさせたいfdsを渡す
+  return unresponsive_clients;
+}
 
 ClientRegistry &ClientRegistry::operator=(const ClientRegistry &other) {
   (void)other;

--- a/srcs/event/EpollMultiplexer.cpp
+++ b/srcs/event/EpollMultiplexer.cpp
@@ -4,12 +4,12 @@
 #include <iostream>
 
 Multiplexer &EpollMultiplexer::get_instance() {
-  if (!Multiplexer::instance) {
+  if (!Multiplexer::instance_) {
     log(LOG_INFO, "EpollMultiplexer::get_instance()");
-    Multiplexer::instance = new EpollMultiplexer();
+    Multiplexer::instance_ = new EpollMultiplexer();
     std::atexit(Multiplexer::delete_instance);
   }
-  return *Multiplexer::instance;
+  return *Multiplexer::instance_;
 }
 
 void EpollMultiplexer::run() {
@@ -27,8 +27,9 @@ void EpollMultiplexer::run() {
       throw std::runtime_error("epoll event list exceeds limit");
     }
     evlist.resize(size);
+    handle_timeouts();
     errno = 0;
-    int nfd = epoll_wait(epfd, evlist.data(), evlist.size(), 0);
+    int nfd = epoll_wait(epfd, evlist.data(), evlist.size(), k_timeout_ms_);
     if (nfd == -1) {
       if (errno == EINTR) {
         continue;

--- a/srcs/event/PollMultiplexer.cpp
+++ b/srcs/event/PollMultiplexer.cpp
@@ -8,12 +8,12 @@
 #include <sys/socket.h>
 
 Multiplexer &PollMultiplexer::get_instance() {
-  if (!Multiplexer::instance) {
+  if (!Multiplexer::instance_) {
     log(LOG_INFO, "PollMultiplexer::get_instance()");
-    Multiplexer::instance = new PollMultiplexer();
+    Multiplexer::instance_ = new PollMultiplexer();
     std::atexit(Multiplexer::delete_instance);
   }
-  return *Multiplexer::instance;
+  return *Multiplexer::instance_;
 }
 
 void PollMultiplexer::run() {
@@ -28,8 +28,9 @@ void PollMultiplexer::run() {
     if (pfds.size() >= max_poll_events) {
       throw std::runtime_error("poll() fd count exceeds limit");
     }
+    handle_timeouts();
     errno = 0;
-    int nfd = poll(pfds.data(), pfds.size(), 0);
+    int nfd = poll(pfds.data(), pfds.size(), k_timeout_ms_);
     if (nfd == -1) {
       if (errno == EINTR) {
         continue;

--- a/tests/test_unresponsive.py
+++ b/tests/test_unresponsive.py
@@ -1,0 +1,12 @@
+# test_unresponsive.py
+
+import socket
+import time
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.connect(('localhost', 8080))
+
+sock.sendall(b"GET / HTTP/1.1\r\nHost: localhost\r\n")
+sock.shutdown(socket.SHUT_RD)
+time.sleep(30)
+


### PR DESCRIPTION
## 概要

Client接続に対する **timeout処理** を実装

### 💫 処理の流れ

各 `Client` インスタンスは `time_t last_activity_` を持ち、最後の activity（read/write）時刻を記録する

1. `Multiplexer` が定期的に `last_activity_` を確認し、timeout した client を検出
2. timeout していた場合、server は `408 Request Timeout` を `Connection: close` ヘッダ付きで送信
3. response 送信後、**write方向のみ shutdown（half-close）**
4. その後のパターンは2通り：
   - **(a)** client が `Connection: close` に従って接続を閉じた場合：通常通り `read()` の EOF 検出で `close(fd)`
   - **(b)** client が無視して放置した場合：一定時間後に **server 側で強制 close**

サーバが shutdown(fd, SHUT_WR) を呼び出すと、TCPレベルで FIN（EOF）が送信され
それを受け取った nc や curl、Python の socket は自動的に接続を終了するので
クライアントが応答せず放置するケース（b）は確認しにくい

## テスト方法

```bash
echo -e "GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n" | nc localhost 8080

# または
python3 tests/test_unresponsive.py
```

## 関連
- ref #69