### PR TITLE
fix: server_name未設定のserverによるセグフォを修正

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "types.hpp"
+#include <cstddef>
+#include <iostream>
 #include <map>
 #include <string>
 #include <vector>
-#include <cstddef>
-#include <iostream>
 
 class Server {
 public:
@@ -15,16 +15,16 @@ public:
 
   const ConfigMap &get_config() const;
   const LocationMap &get_locations() const;
+  const std::vector<std::string> &get_server_names() const;
 
-  bool matches_host(const std::string &host) const;
   bool is_default_server() const;
 
 private:
-  ConfigMap server_config;
-  LocationMap location_configs;
+  ConfigMap server_config_;
+  LocationMap location_configs_;
 
-  std::string public_root;
-  std::string error_404;
+  std::string public_root_;
+  std::string error_404_;
   bool _is_default;
 
   Server();

--- a/includes/VirtualHostRouter.hpp
+++ b/includes/VirtualHostRouter.hpp
@@ -15,8 +15,8 @@ public:
   Server *route_by_host(const std::string &host) const;
 
 private:
-  std::vector<Server *> servers;
-  Parse parser;
+  std::vector<Server *> servers_;
+  Parse parser_;
 
   VirtualHostRouter(const VirtualHostRouter &other);
   VirtualHostRouter &operator=(const VirtualHostRouter &other);

--- a/srcs/http/HttpRequest.cpp
+++ b/srcs/http/HttpRequest.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:37:05 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/04/30 00:36:26 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/05/16 17:09:56 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,8 @@ HttpRequest::~HttpRequest() {}
 
 // note: 適切なHost nameが存在することは、parser側で検証済みとする
 void HttpRequest::select_server_by_host() {
+  LOG_DEBUG_FUNC();
+
   const std::string host_name = get_header_value("Host");
   Server *server = virtual_host_router->route_by_host(host_name);
   this->server_config = server->get_config();
@@ -62,6 +64,7 @@ void HttpRequest::init_file_index() {
 }
 
 void HttpRequest::conf_init() {
+  LOG_DEBUG_FUNC();
   this->best_match_config = get_best_match_config(path);
 
   if (!best_match_config["root"].empty())
@@ -559,6 +562,7 @@ bool HttpRequest::is_cgi_request(const std::string &path) {
 }
 
 void HttpRequest::print_best_match_config() const {
+  LOG_DEBUG_FUNC();
   std::cout << "=== best_match_config ===" << std::endl;
   for (ConstConfigIt it = best_match_config.begin();
        it != best_match_config.end(); ++it) {

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -4,13 +4,13 @@
 
 // TODO: 確認
 Server::Server(const ConfigMap &config, const LocationMap &locations)
-    : server_config(config), location_configs(locations) {
+    : server_config_(config), location_configs_(locations) {
 
   ConstConfigIt error_it = config.find("error_page 404");
-  error_404 = (error_it != config.end() && !error_it->second.empty())
-                  ? error_it->second[0]
-                  : "404.html";
-  
+  error_404_ = (error_it != config.end() && !error_it->second.empty())
+                   ? error_it->second[0]
+                   : "404.html";
+
   ConstConfigIt listen_it = config.find("listen");
   if (listen_it != config.end()) {
     const std::vector<std::string> &tokens = listen_it->second;
@@ -25,34 +25,28 @@ Server::Server(const ConfigMap &config, const LocationMap &locations)
 
 // TODO: 確認
 Server::Server(const Server &src) {
-  server_config = src.server_config;
-  location_configs = src.location_configs;
-  public_root = src.public_root;
-  error_404 = src.error_404;
+  server_config_ = src.server_config_;
+  location_configs_ = src.location_configs_;
+  public_root_ = src.public_root_;
+  error_404_ = src.error_404_;
   _is_default = src._is_default;
 }
 
 Server::~Server() {}
 
-const ConfigMap &Server::get_config() const { return server_config; }
+const ConfigMap &Server::get_config() const { return server_config_; }
 
-const LocationMap &Server::get_locations() const { return location_configs; }
+const LocationMap &Server::get_locations() const { return location_configs_; }
 
-// TODO: wildcard server_name への対応（ ex. *.example.com ）
-bool Server::matches_host(const std::string &host_name) const {
-  ConstConfigIt it = server_config.find("server_name");
-  if (it == server_config.end()) {
-    return false;
-  }
-  const std::vector<std::string> &names = it->second;
-  return std::find(names.begin(), names.end(), host_name) != names.end();
+const std::vector<std::string> &Server::get_server_names() const {
+  static const std::vector<std::string> k_empty;
+  ConstConfigIt it = server_config_.find("server_name");
+  return (it == server_config_.end()) ? k_empty : it->second;
 }
+
+bool Server::is_default_server() const { return _is_default; }
 
 Server &Server::operator=(const Server &src) {
   (void)src;
   return *this;
-}
-
-bool Server::is_default_server() const {
-  return _is_default;
 }


### PR DESCRIPTION
## 概要
confに `server_name` 未設定の `server` が含まれていると、
VirtualHostRouter::route_by_host() 内で `it->second` を参照しようとしてセグフォしていた

## 対応
`Server::get_server_names()` を新たに定義し、`server_name` が存在しない場合は
空の `std::vector<std::string>` を返すことで、呼び出し側が安全に処理できるように修正