### PR TITLE
fix/epoll ctl error

### DIFF
--- a/includes/EpollMultiplexer.hpp
+++ b/includes/EpollMultiplexer.hpp
@@ -27,9 +27,9 @@ private:
   typedef std::set<int>::iterator FdBackupIt;
   typedef std::set<int>::const_iterator ConstFdBackupIt;
 
-  int epfd;
-  std::set<int> read_fds;
-  std::set<int> write_fds;
+  int epfd_;
+  std::set<int> read_fds_;
+  std::set<int> write_fds_;
 
   bool is_readable(struct epoll_event &ev) const;
   bool is_writable(struct epoll_event &ev) const;
@@ -43,13 +43,3 @@ private:
 
   EpollMultiplexer &operator=(const EpollMultiplexer &other);
 };
-
-// TODO: dup()して、fdの複製が生じたときの管理
-// note: edge-triggered にするにはev.events = EPOLLIN | EPOLLET;する
-/*
-TODO: max_user_watches の反映
-c5r1s4% cat /proc/sys/fs/epoll/max_user_watches
-3599293
-TODO: handling EPOLLRDHUP, EPOLLHUP, EPOLLERR は大丈夫か？
-*/
-// add, remove に失敗したfdはどこでcloseするべきか？

--- a/srcs/event/EpollMultiplexer.cpp
+++ b/srcs/event/EpollMultiplexer.cpp
@@ -16,10 +16,7 @@ void EpollMultiplexer::run() {
   LOG_DEBUG_FUNC();
   static const int max_epoll_events = 3599293;
   int size = 16; // num of fd; expect to monitor; not upper limit
-  epfd = epoll_create(size);
-  if (epfd == -1) {
-    throw std::runtime_error("epoll_create");
-  }
+
   std::vector<struct epoll_event> evlist;
 
   while (true) {
@@ -148,7 +145,12 @@ bool EpollMultiplexer::is_in_write_fds(int fd) const {
   return write_fds.find(fd) != write_fds.end();
 }
 
-EpollMultiplexer::EpollMultiplexer() {}
+EpollMultiplexer::EpollMultiplexer() {
+  epfd = epoll_create(16);
+  if (epfd == -1) {
+    throw std::runtime_error("epoll_create");
+  }
+}
 
 EpollMultiplexer::EpollMultiplexer(const EpollMultiplexer &other)
     : Multiplexer(other) {}


### PR DESCRIPTION
### 概要
epfdの初期化をする前に、epoll_ctl()の呼び出しをしようとして
エラーになっていた。epfdの初期化の位置を変えて対処した

### 対策
epfd = epoll_create(16); の位置をepollコンストラクタ内に変更した