### PR TITLE
Fix/load body size他

### DIFF
--- a/includes/HttpRequest.hpp
+++ b/includes/HttpRequest.hpp
@@ -47,7 +47,7 @@ public:
   std::string version_;
   HeaderMap headers_;
   std::vector<char> body_data_;
-
+  size_t body_size_;
 
   bool is_autoindex_enabled_;
   std::string index_file_name_;
@@ -59,7 +59,8 @@ public:
   LocationMap location_configs_;
   ConfigMap best_match_config_;
 
-  HttpRequest(int fd, const VirtualHostRouter *router, HttpResponse &httpResponse);
+  HttpRequest(int fd, const VirtualHostRouter *router,
+              HttpResponse &httpResponse);
   ~HttpRequest();
 
   void handle_http_request();
@@ -70,6 +71,9 @@ public:
   const std::string &get_method() const { return method_; }
   const std::string &get_path() const { return path_; }
   const std::vector<char> &get_body() const { return body_data_; }
+
+  size_t get_body_size() const { return body_size_; }
+  void set_body_size(size_t size) { body_size_ = size; }
 
   void set_status_code(int status);
   int get_status_code() const;
@@ -101,7 +105,6 @@ private:
   int status_code_;
   std::string _root;
   size_t max_body_size_;
-  size_t body_size_;
 
   static const size_t k_default_max_body_;
 
@@ -133,7 +136,7 @@ private:
 
   RedirStatus handle_redirection();
   void launch_cgi(const std::string &cgi_path);
-  
+
   void load_body_size();
   size_t get_body_size();
   bool validate_client_body_size();

--- a/includes/HttpRequest.hpp
+++ b/includes/HttpRequest.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   HttpRequest.hpp                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: koseki.yusuke <koseki.yusuke@student.42    +#+  +:+       +#+        */
+/*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:44:38 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/06/28 16:43:02 by koseki.yusu      ###   ########.fr       */
+/*   Updated: 2025/07/05 15:32:40 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -137,8 +137,6 @@ private:
   RedirStatus handle_redirection();
   void launch_cgi(const std::string &cgi_path);
 
-  void load_body_size();
-  size_t get_body_size();
   bool validate_client_body_size();
 
   HttpRequest(const HttpRequest &other);

--- a/includes/HttpRequestParser.hpp
+++ b/includes/HttpRequestParser.hpp
@@ -29,7 +29,6 @@ private:
 
   HttpRequest &request;
   ParseState parse_state;
-  size_t body_size;
   std::vector<char> recv_buffer;
 
   void parse_header();

--- a/includes/Logger.hpp
+++ b/includes/Logger.hpp
@@ -7,7 +7,6 @@
 enum LogLevel { LOG_FUNC, LOG_INFO, LOG_DEBUG, LOG_WARNING, LOG_ERROR };
 
 extern LogLevel current_log_level;
-extern std::ofstream debug_log;
 
 void log(LogLevel level, const std::string &message);
 void logfd(LogLevel level, const std::string &prefix, int fd);

--- a/srcs/client/ClientRegistry.cpp
+++ b/srcs/client/ClientRegistry.cpp
@@ -32,7 +32,6 @@ void ClientRegistry::remove(int fd) {
 Client *ClientRegistry::get(int fd) const {
   ConstClientIt it = fd_to_clients_.find(fd);
   if (it == fd_to_clients_.end()) {
-    logfd(LOG_ERROR, "Failed to find client fd: ", fd);
     return NULL;
   }
   return it->second;

--- a/srcs/config/ConfigParse.cpp
+++ b/srcs/config/ConfigParse.cpp
@@ -376,12 +376,6 @@ void Parse::handle_server_block(const std::string& line, std::map<std::string, s
             current_config[key] = values;
         }
     }
-    std::cout << "Parsed config: key='" << key << "', values=[";
-    for (size_t i = 0; i < values.size(); ++i) {
-        std::cout << values[i];
-        if (i < values.size() - 1) std::cout << ", ";
-    }
-    std::cout << "]\n";
 }
 
 /* parser utils */

--- a/srcs/event/Multiplexer.cpp
+++ b/srcs/event/Multiplexer.cpp
@@ -147,6 +147,9 @@ void Multiplexer::accept_client(int serverfd) {
 void Multiplexer::read_from_client(int clientfd) {
   LOG_DEBUG_FUNC_FD(clientfd);
   Client *client = client_registry_->get(clientfd);
+  if (!client) {
+    return;
+  }
 
   switch (client->on_read()) {
 
@@ -167,6 +170,9 @@ void Multiplexer::read_from_client(int clientfd) {
 void Multiplexer::write_to_client(int clientfd) {
   LOG_DEBUG_FUNC_FD(clientfd);
   Client *client = client_registry_->get(clientfd);
+  if (!client) {
+    return;
+  }
 
   switch (client->on_write()) {
   case IO_CONTINUE:
@@ -205,6 +211,9 @@ void Multiplexer::cleanup_client(int clientfd) {
 void Multiplexer::read_from_cgi(int cgi_stdout) {
   LOG_DEBUG_FUNC_FD(cgi_stdout);
   CgiSession *session = cgi_registry_->get(cgi_stdout);
+  if (!session) {
+    return;
+  }
 
   switch (session->on_cgi_read()) {
   case CGI_IO_CONTINUE:
@@ -226,6 +235,9 @@ void Multiplexer::read_from_cgi(int cgi_stdout) {
 void Multiplexer::write_to_cgi(int cgi_stdin) {
   LOG_DEBUG_FUNC_FD(cgi_stdin);
   CgiSession *session = cgi_registry_->get(cgi_stdin);
+  if (!session) {
+    return;
+  }
 
   switch (session->on_cgi_write()) {
   case CGI_IO_CONTINUE:

--- a/srcs/http/HttpRequest.cpp
+++ b/srcs/http/HttpRequest.cpp
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 16:37:05 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2025/07/05 13:46:52 by sakitaha         ###   ########.fr       */
+/*   Updated: 2025/07/05 15:34:52 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -233,32 +233,9 @@ ConfigMap HttpRequest::get_best_match_config(const std::string &path) {
   return (best_config);
 }
 
-size_t HttpRequest::get_body_size() { return body_size_; }
-
-void HttpRequest::load_body_size() {
-  if (is_in_headers("Content-Length")) {
-
-    StrVector num_values = get_header_values("Content-Length");
-    if (num_values.empty()) {
-      return;
-    }
-    try {
-      body_size_ = str_to_size(num_values[0]);
-    } catch (const std::exception &e) {
-      return;
-    }
-    for (size_t i = 1; i < num_values.size(); ++i) {
-      if (num_values[i] != num_values[0]) {
-        return;
-      }
-    }
-  }
-}
-
 bool HttpRequest::validate_client_body_size() {
   // body size の超過;
   load_max_body_size();
-  load_body_size();
   if (body_size_ > get_max_body_size()) {
     set_status_code(413);
     return false;
@@ -644,8 +621,9 @@ void HttpRequest::clear() {
   method_.clear();
   path_.clear();
   version_.clear();
-  body_data_.clear();
   headers_.clear();
+  body_data_.clear();
+  body_size_ = 0;
 
   is_autoindex_enabled_ = false;
   index_file_name_.clear();
@@ -657,6 +635,7 @@ void HttpRequest::clear() {
   location_configs_.clear();
   best_match_config_.clear();
   _root.clear();
+  max_body_size_ = k_default_max_body_;
 
   connection_policy_ = CP_KEEP_ALIVE;
   status_code_ = 0;

--- a/srcs/http/HttpRequestParser.cpp
+++ b/srcs/http/HttpRequestParser.cpp
@@ -108,6 +108,7 @@ void HttpRequestParser::next_parse_state() {
 
 void HttpRequestParser::parse_body() {
   LOG_DEBUG_FUNC();
+  size_t body_size = request.get_body_size();
   if (body_size == 0) {
     parse_state = PARSE_DONE;
     return;
@@ -306,7 +307,8 @@ bool HttpRequestParser::check_framing_error() {
       return false;
     }
     try {
-      body_size = str_to_size(num_values[0]);
+      size_t body_size = str_to_size(num_values[0]);
+      request.set_body_size(body_size);
     } catch (const std::exception &e) {
       return false;
     }

--- a/srcs/http/HttpRequestParser.cpp
+++ b/srcs/http/HttpRequestParser.cpp
@@ -43,7 +43,6 @@ void HttpRequestParser::clear() {
   LOG_DEBUG_FUNC();
   request.clear();
   parse_state = PARSE_HEADER;
-  body_size = 0;
 }
 
 void HttpRequestParser::append_data(const char *data, size_t length) {

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -23,10 +23,7 @@
 #include <signal.h>
 #include <sys/wait.h>
 
-static void free_resources() {
-  Multiplexer::delete_instance();
-  debug_log.close();
-}
+static void free_resources() { Multiplexer::delete_instance(); }
 
 static void handle_sigchld(int sig) {
   const int saved_errno = errno;

--- a/srcs/utils/Logger.cpp
+++ b/srcs/utils/Logger.cpp
@@ -9,41 +9,31 @@
 
 LogLevel current_log_level = static_cast<LogLevel>(LOG_LEVEL);
 
-std::ofstream debug_log("debug.log");
-
 void log(LogLevel level, const std::string &message) {
   if (level >= current_log_level) {
     switch (level) {
     case LOG_FUNC:
       std::cout << CYAN << "[FUNC] " << RESET << message << std::endl;
-      debug_log << "[FUNC] " << message << std::endl;
       break;
     case LOG_INFO:
       std::cout << GREEN << "[INFO] " << RESET << message << std::endl;
-      debug_log << "[INFO] " << message << std::endl;
       break;
     case LOG_DEBUG:
-      debug_log << "[DEBUG] " << message << std::endl;
       break;
     case LOG_WARNING:
       std::cerr << YELLOW << "[WARNING] " << RESET << message << std::endl;
-      debug_log << "[WARNING] " << message << std::endl;
       break;
     case LOG_ERROR:
       std::cerr << RED << "[ERROR] " << RESET << message;
-      debug_log << "[ERROR] " << message;
       if (errno != 0) {
         int err = errno;
         errno = 0;
         std::cerr << " (errno: " << err << ", reason: " << strerror(err) << ")";
-        debug_log << " (errno: " << err << ", reason: " << strerror(err) << ")";
       }
       std::cerr << std::endl;
-      debug_log << std::endl;
       break;
     default:
       std::cerr << "[UNKNOWN] " << message << std::endl;
-      debug_log << "[UNKNOWN] " << message << std::endl;
     }
   }
 }


### PR DESCRIPTION
- body sizeの読み込みを、parserがrequestの値を更新する形式に変更
- セグフォの要因になっていたepollとのclient削除タイミングのずれに対応
- その他、不要なコメントを削除
- debug_logの出力をなくした